### PR TITLE
Releasing docs

### DIFF
--- a/docs/Developers/releasing.md
+++ b/docs/Developers/releasing.md
@@ -1,0 +1,45 @@
+---
+title: 'How To Cut A Release'
+---
+
+In the open-source version of Actual, all updates go through npm. There are two libraries:
+
+`@actual-app/api`: The API for the underlying functionality. This includes the entire backend of Actual, meant to be used with node.
+`@actual-app/web`: A web build that will serve the app with a web frontend. This includes both the frontend and backend of Actual. It includes the backend as well because it's built to be used as a Web Worker.
+
+Both the API and web libraries are versioned together. This may change in the future, but because the web library also brings along its own backend it's easier to maintain a single version for now. That makes it clear which version the backend is regardless of library.
+Releasing @actual-app/api
+
+### This generates a bundle for the API:
+
+```bash
+cd packages/loot-core
+yarn build:api
+```
+
+The built files live in `lib-dist`, so we need to copy them to the API package:
+
+```bash
+cp lib-dist/bundle.api* ../api/app
+```
+
+Next, bump the version on package.json. Finally, publish it:
+
+```bash
+npm publish
+```
+
+### Releasing @actual-app/web
+
+In the root of actual (not just desktop-client), run this:
+
+```bash
+./bin/package-browser
+```
+
+This will compile both the backend and the frontend into a single directory in packages/desktop-client/build. This directory is all the files that need to be published. After bumping the version, publish desktop-client:
+
+```bash
+cd packages/desktop-client
+npm publish
+```

--- a/docs/Installing/overview.md
+++ b/docs/Installing/overview.md
@@ -1,0 +1,19 @@
+---
+title: 'Overview'
+---
+
+Installing Actual be it on your own personal computer or in the cloud is really simple, we have a selection of guides available that will help you get setup, but first, there are some things your going to need and also some things we need to tell you that we currently don't support.
+
+### Pre Requisites  
+
+* Windows, OSX or Linux operating system
+* [NodeJS](https://nodejs.org/en/) version 14 or greater
+* Access to the internet
+* [Yarn](https://yarnpkg.com/)
+
+### Currently Not Supported 
+
+The following is currently not supported by Actual.
+
+* [Nomad](https://www.nomadproject.io/)
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -30,6 +30,7 @@ const sidebars = {
         type: 'generated-index',
       },
       items: [
+        'Installing/overview',
         {
           type: 'category',
           label: 'On Your Own Server',

--- a/sidebars.js
+++ b/sidebars.js
@@ -178,6 +178,7 @@ const sidebars = {
       collapsed: true,
       items: [
         'Developers/project-layout',
+        'Developers/releasing',
         'Developers/using-the-API',
         'Developers/API',
         'Developers/ActualQL',


### PR DESCRIPTION
Migrating documentation from https://github.com/actualbudget/actual/blob/master/docs/releasing.md, this resolves #22 