### PR TITLE
Update release notes regarding 22.12.03

### DIFF
--- a/docs/Release-Notes/Release-Notes.md
+++ b/docs/Release-Notes/Release-Notes.md
@@ -3,12 +3,22 @@ title: Releases Notes
 ---
 
 ## 22.12.03
+**Docker tag: 22.12.9**
+
+:::warning
+
+ If you are upgrading from a release older than 22.10.25, read that versions release notes for steps regarding a breaking change.
+
+ Using Docker tags 22.12.3 or 22.12.8 have errors.  **Use Docker tag 22.12.9**
+
+:::
 
 The release has notable of improvements of:
 * Large values are supported
 * Fix YNAB 4 and nYnab importers
 * Fixed crashes in certain situations
 * Accounts can now have notes
+* Icon design was changed for more contrast.
 
 A full accounting of the changes are listed below.  Thank you to everyone who contributed!
 
@@ -25,11 +35,13 @@ A full accounting of the changes are listed below.  Thank you to everyone who co
 * [#396](https://github.com/actualbudget/actual/pull/396) Avoid pulling in the bundled app from API in backend -- thanks [jlongster](https://github.com/jlongster)
 
 ### Actual Server
+Version : 22.12.09
 
-No changes
+Builds with Actual 22.12.03 and API 4.1.5.
 
 
 ## 22.10.25
+**Docker tag: 22.10.25**
 
 :::warning
 This release includes a breaking change to the sync component that requires manual migration ([migration guide](/Getting-Started/migration/simple-sync)). Ensure your budget is [backed up](/Backup-Restore/Backups) before you update to avoid data loss

--- a/docs/Release-Notes/Release-Notes.md
+++ b/docs/Release-Notes/Release-Notes.md
@@ -23,6 +23,8 @@ The release has notable of improvements of:
 A full accounting of the changes are listed below.  Thank you to everyone who contributed!
 
 ### Actual
+Version: 22.12.03
+
 * [#218](https://github.com/actualbudget/actual/pull/218) Fix enter to create accounts -- thanks [ezfe](https://github.com/ezfe))
 * [#266](https://github.com/actualbudget/actual/pull/266) RUpdate data-file-index.txt -- thanks [j-f1](https://github.com/j-f1)
 * [#272](https://github.com/actualbudget/actual/pull/272) a11y: update cleared state display for clarity -- thanks [rickdoesdev](https://github.com/rickdoesdev)
@@ -54,6 +56,7 @@ This release of Actual does not include any of the following
 * Android Application
 
 ### Actual
+Version: 22.10.25
 
 * [#1](https://github.com/actualbudget/actual/pull/1) Add fields to package.json -- thanks [coliff](https://github.com/coliff)
 * [#3](https://github.com/actualbudget/actual/pull/3) Create .editorconfig -- thanks [coliff](https://github.com/coliff)
@@ -123,6 +126,7 @@ This release of Actual does not include any of the following
 * [#262](https://github.com/actualbudget/actual/pull/262) Render a schedule rule with the mapped payee id; fixes crash -- thanks [jlongster](https://github.com/jlongster)
 
 ### Actual Server
+Version: 22.10.25
 
 * [#1](https://github.com/actualbudget/actual-server/pull/1) - Adjust Dockerfile to build successfully -- thanks [Kovah](https://github.com/Kovah)
 * [#2](https://github.com/actualbudget/actual-server/pull/2) - Instructions for running via Docker -- thanks [ajtrichards](https://github.com/ajtrichards)


### PR DESCRIPTION
I've update the release notes regarding the recent update.  Here is a summary.

1) Added some notes for the release page regarding the Docker tags and warning about the 22.12.3 and 22.12.8 tags.  
2) Highlighted the icon change in the features list
3) Added the final published docker tag for each of the releases.
