### PR TITLE
Add docs for the config file and HTTPS

### DIFF
--- a/docs/Installing/Configuration.md
+++ b/docs/Installing/Configuration.md
@@ -1,0 +1,35 @@
+---
+title: Configuring the Server
+---
+
+When it starts up, Actual looks for a `config.json` file in the same directory as its `package.json`. If present, any keys you define there will override the default values. Here are the supported keys:
+
+## `https`
+
+If you want to Actual to serve over HTTPS, you can set this key to an object with the following keys:
+
+- `key`: The path to the private key file.
+- `cert`: The path to the certificate file.
+- any other options from Node’s [`tls.createServer()`](https://nodejs.org/docs/latest-v16.x/api/tls.html#tlscreateserveroptions-secureconnectionlistener), [`tls.createSecureContext()`](https://nodejs.org/docs/latest-v16.x/api/tls.html#tlscreatesecurecontextoptions), or [`http.createServer()`](https://nodejs.org/docs/latest-v16.x/api/http.html#httpcreateserveroptions-requestlistener) functions (optional, most people won’t need to set any of these).
+
+<!-- ## `mode`
+
+The `mode` key is not currently used by anything, as far as I can tell. It’s exposed on the `/mode` route, but that route does not appear to be called by the frontend. -->
+
+## `port`
+
+The `port` key is used to specify the port that the server should listen on. If not specified, the server will listen on port 5006.
+
+## `hostname`
+
+The `hostname` key is used to specify the hostname that the server should listen on. If not specified, the server will listen on `::` (which, on most operating systems, will include both IPv4 and IPv6).
+
+## `serverFiles`
+
+The server will put an `account.sqlite` file in this directory, which will contain the (hashed) server password, a list of all the budget files the server knows about, and the active session token (along with anything else the server may want to store in the future). If not specified, the server will use the `server-files` directory in the same directory as the `package.json`.
+
+## `userFiles`
+
+The server will put all the budget files in this directory as binary blobs. If not specified, the server will use the `user-files` directory in the same directory as the `package.json`.
+
+If the `ACTUAL_USER_FILES` environment variable is set, it will override this value.

--- a/docs/Installing/Configuration.md
+++ b/docs/Installing/Configuration.md
@@ -2,7 +2,7 @@
 title: Configuring the Server
 ---
 
-When it starts up, Actual looks for a `config.json` file in the same directory as its `package.json`. If present, any keys you define there will override the default values. Here are the supported keys:
+When it starts up, Actual looks for an optional `config.json` file in the same directory as its `package.json`. If present, any keys you define there will override the default values. Here are the supported keys:
 
 ## `https`
 

--- a/docs/Installing/overview.md
+++ b/docs/Installing/overview.md
@@ -13,4 +13,6 @@ While running a server can be a complicated endeavor, we’ve tried to make it f
   - If you want to use Docker, we have instructions for [running Actual directly](Docker.md) inside Docker or [behind an nginx proxy that offers HTTPS support](DockerWithNginx.md).
 - If you have a home server or a NAS running [Unraid](Unraid.md) or [Synology](synology/synology.md), we have instructions for installing Actual on those platforms.
 
+Once you’ve set up your server, you can [configure it](Configuration.md) to change a few of the ways it works.
+
 If you have any other ways Actual can be hosted, please consider opening a pull request to add them to the documentation so that others can benefit from your experience.

--- a/docs/Troubleshooting/SharedArrayBuffer.md
+++ b/docs/Troubleshooting/SharedArrayBuffer.md
@@ -14,7 +14,7 @@ If youâ€™re running a local server and accessing it through a domain name, youâ€
 2. Connect your server to a domain you control and make it public to the Internet. You could use a tool like [certbot](https://certbot.eff.org) to generate a valid certificate once you have the domain set up.
 3. Use a service like [Tailscale](https://tailscale.com/kb/1153/enabling-https/) that allows you to create a valid HTTPS certificate without having to expose your server to the wider internet.
 
-Once you have the certificate, [pass it to Actual using the config file](/Installing/Configuration/#https)
+Once you have the certificate, [pass it to Actual using the config file](/Installing/Configuration/#https).
 
 ## HTTP Headers
 

--- a/docs/Troubleshooting/SharedArrayBuffer.md
+++ b/docs/Troubleshooting/SharedArrayBuffer.md
@@ -14,6 +14,8 @@ If you’re running a local server and accessing it through a domain name, you�
 2. Connect your server to a domain you control and make it public to the Internet. You could use a tool like [certbot](https://certbot.eff.org) to generate a valid certificate once you have the domain set up.
 3. Use a service like [Tailscale](https://tailscale.com/kb/1153/enabling-https/) that allows you to create a valid HTTPS certificate without having to expose your server to the wider internet.
 
+Once you have the certificate, [pass it to Actual using the config file](/Installing/Configuration/#https)
+
 ## HTTP Headers
 
 In addition to the HTTPS requirement, the `Cross-Origin-Embedder-Policy` and `Cross-Origin-Opener-Policy` headers must be set to `require-corp` and `same-origin` respectively. If you’re using the default `actual-server` package as your server, you don’t have to worry about this (the headers will always be enabled). If you’re using a different server, you’ll need to make sure these headers are set.

--- a/sidebars.js
+++ b/sidebars.js
@@ -108,6 +108,7 @@ const sidebars = {
             },
           ],
         },
+        'Installing/Configuration',
         {
           type: 'category',
           label: 'A Tour of Actual',


### PR DESCRIPTION
HTTPS support will only be available after the next release of Actual, so it may make sense to wait to merge this until the release happens.