### PR TITLE
Update Fly-updating.md- Add info about updating fly.toml before deployment

### DIFF
--- a/docs/Installing/fly/Fly-updating.md
+++ b/docs/Installing/fly/Fly-updating.md
@@ -38,7 +38,7 @@ git pull origin master
 ```
 ![](/img/cmd-25.png)
 
-Once that is done, run the deployment command to push your changes to fly.
+Once that is done, check if your fly.toml file is up to date with fly.template.toml and then run the deployment command to push your changes to fly.
 ```cmd
 flyctl deploy.
 ```

--- a/docs/Installing/fly/Fly-updating.md
+++ b/docs/Installing/fly/Fly-updating.md
@@ -38,7 +38,18 @@ git pull origin master
 ```
 ![](/img/cmd-25.png)
 
-Once that is done, check if your fly.toml file is up to date with fly.template.toml and then run the deployment command to push your changes to fly.
+:::info
+As the fly.toml is excluded in the gitignore changes made upstream will not be pulled down, ensure you check the fly.toml against the fly.template.toml using the steps below before proceeding
+:::
+
+At this point, open the fly.toml (this should be located in `C:\github\actual-server`) by right clicking on it and selecting `Open` it should open in a text editor. 
+
+Open the fly.template.toml by doing the same steps as above.
+
+Once the two files are open, compare the fly.toml to the fly.template.toml ensuring that everything below the `app = "%NAME%"` is the same. 
+
+Once that is done, run the deployment command to push your changes to fly.
+
 ```cmd
 flyctl deploy.
 ```


### PR DESCRIPTION
I have a suggestion for the "Updating Actual" doc page. Since fly.toml is in .gitignore pulling changes via git won't update it. Users should also update their fly.toml before deploying on server. 
I added short info in the Fly-updating.md. However I don't know if this info should also be updated elsewhere.
