### PR TITLE
Add note on migration from old version

### DIFF
--- a/docs/Getting-Started/migration/migration-intro.md
+++ b/docs/Getting-Started/migration/migration-intro.md
@@ -6,9 +6,13 @@ title: "Migration Overview"
 [Click here](simple-sync) if you are looking for the steps to migrate from "full sync" to (the more reliable) "simple sync" method.
 :::
 
+
 Keeping your existing transaction history is important. If you already use a different app, you probably want to migrate it over into Actual.
 
 Right now, only YNAB4 is officially supported. However, the [API](/developers/API/) allows anyone to write a custom importer. We will work with the community to help write other importers soon.
+
+## Migration from the old Desktop App
+The Desktop app that was tied to the old hosted instance of ActualBudget does not have the export button which is available in the Web version and in newer versions of the Desktop app (see https://github.com/actualbudget/actual/pull/71). To export your data, log in to the Web version at https://app.actualbudget.com. Here you can export your data using Settings > Export Data. The export can be imported into newer versions of the Web app and Desktop app.
 
 ## Migration from other apps
 

--- a/docs/Getting-Started/migration/migration-intro.md
+++ b/docs/Getting-Started/migration/migration-intro.md
@@ -12,7 +12,11 @@ Keeping your existing transaction history is important. If you already use a dif
 Right now, only YNAB4 is officially supported. However, the [API](/developers/API/) allows anyone to write a custom importer. We will work with the community to help write other importers soon.
 
 ## Migration from the old Desktop App
-The Desktop app that was tied to the old hosted instance of ActualBudget does not have the export button which is available in the Web version and in newer versions of the Desktop app (see https://github.com/actualbudget/actual/pull/71). To export your data, log in to the Web version at https://app.actualbudget.com. Here you can export your data using Settings > Export Data. The export can be imported into newer versions of the Web app and Desktop app.
+:::note
+Are you coming from the original, managed Actual subscription service? That used an older version of the desktop app which doesn't have the export button, but you can log in to the Web version at app.actualbudget.com to export your data in a format suitable for importing in your new instance. See [Backups](https://actualbudget.github.io/docs/Backup-Restore/Backups) and [Restoring](https://actualbudget.github.io/docs/Backup-restore/Restore).
+
+Instead of creating an export from the Web app, you can also create a zip archive of your budget folder, which is equivalent. The folder is located at `~/Documents/Actual/My-Budget-abc123` by default on MacOS and Linux. The resulting zip file can be imported into Actual via the Web app.
+:::note
 
 ## Migration from other apps
 

--- a/docs/Installing/overview.md
+++ b/docs/Installing/overview.md
@@ -15,4 +15,6 @@ While running a server can be a complicated endeavor, we’ve tried to make it f
 
 Once you’ve set up your server, you can [configure it](Configuration.md) to change a few of the ways it works.
 
+If you're coming from the old, hosted version of Actual, you may want to [migrate your data](../Getting-Started/migration/migration-intro.md).
+
 If you have any other ways Actual can be hosted, please consider opening a pull request to add them to the documentation so that others can benefit from your experience.

--- a/docs/Installing/overview.md
+++ b/docs/Installing/overview.md
@@ -15,6 +15,6 @@ While running a server can be a complicated endeavor, we’ve tried to make it f
 
 Once you’ve set up your server, you can [configure it](Configuration.md) to change a few of the ways it works.
 
-If you're coming from the old, hosted version of Actual, you may want to [migrate your data](../Getting-Started/migration/migration-intro.md).
+If you're coming from the original, managed Actual subscription service, you may want to [migrate your data](../Getting-Started/migration/migration-intro.md).
 
 If you have any other ways Actual can be hosted, please consider opening a pull request to add them to the documentation so that others can benefit from your experience.


### PR DESCRIPTION
closes #25 

It can be confusing for users of the old hosted Actual who want to migrate to the new self-hosted version, because the old Desktop app doesn't have the export button.

This PR adds a note to the Migration page about using the Web version which does have the export button, and links to it from the Installation overview.