### PR TITLE
Update HTTPS certs when using config.json

### DIFF
--- a/docs/Installing/HTTPS.md
+++ b/docs/Installing/HTTPS.md
@@ -16,8 +16,8 @@ Once you have the certificate, you’ll need to configure Actual to use it. Ther
    ```json
    {
      "https": {
-       "keyPath": "/data/selfhost.key",
-       "certPath": "/data/selfhost.crt"
+       "key": "/data/selfhost.key",
+       "cert": "/data/selfhost.crt"
      }
    }
    ```


### PR DESCRIPTION
Based on the code, the paths are no longer `keyPath` and `certPath`. This errors when using the config.json file.

The server looks for `key` and `cert`:
```
key: parseHTTPSConfig(config.https.key),
cert: parseHTTPSConfig(config.https.cert)
```

https://github.com/actualbudget/actual-server/blob/master/src/app.js#L66-L67