### PR TITLE
Updating project information docs

### DIFF
--- a/docs-sidebar.js
+++ b/docs-sidebar.js
@@ -46,7 +46,17 @@ const sidebars = {
           label: 'Feature Requests',
           href: 'https://github.com/actualbudget/actual/issues?q=label%3A%22needs+votes%22+sort%3Areactions-%2B1-desc+',
         },
-        'contributing/project-layout',
+        {
+          type: 'category',
+          label: 'The Actual Project Structure',
+          link: {
+            type: 'doc',
+            id: 'contributing/project-details/index',
+          },
+          items: [
+            'contributing/project-details/database'
+          ]
+        },
         'contributing/preview-builds',
         'contributing/releasing',
         'contributing/windows',

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -36,7 +36,7 @@ Here are some initial guidelines for how contributions will be treated:
 
 ### The Project Layout
 
-The layout of the codebase in Actual Budget takes a bit of getting used to and finding things at first can be a little tricky, we have put together a help [document](./project-layout.md) that shows the structure of the project, while this isn't 100% complete it will give you a good starting point for your development. 
+The layout of the codebase in Actual Budget takes a bit of getting used to and finding things at first can be a little tricky, we have put together a help [document](./project-details/index.md) that shows the structure of the project, while this isn't 100% complete it will give you a good starting point for your development. 
 
 ### Working on existing issues
 

--- a/docs/contributing/project-details/database.md
+++ b/docs/contributing/project-details/database.md
@@ -1,0 +1,9 @@
+# Database Details
+
+Actual stores your data locally inside a sqlite database. You can see the default db structure by opening `/loot-core/default-db.sqlite`
+
+However this is not the 'current' structure, as the database is created as a copy from the default template, and then a series of migrations is run to get the database up to the current level. You can see these migrations in `/loot-core/migrations`.
+
+On the front end, actual sometimes uses views to display data. All the names with the `v_` prefix are actually views, not tables. The views are recreated every time the app starts and normalize the shape of the data to the internal tables. Makes it easy to change field names etc without actually touching the tables (especially important in this local-first world where syncing directly references tables and fields)
+
+Much of the interesting functionality uou might be interested in can be found in `/loot-core/src/server/db`

--- a/docs/contributing/project-details/database.md
+++ b/docs/contributing/project-details/database.md
@@ -6,4 +6,4 @@ However this is not the 'current' structure, as the database is created as a cop
 
 On the front end, actual sometimes uses views to display data. All the names with the `v_` prefix are actually views, not tables. The views are recreated every time the app starts and normalize the shape of the data to the internal tables. Makes it easy to change field names etc without actually touching the tables (especially important in this local-first world where syncing directly references tables and fields)
 
-Much of the interesting functionality uou might be interested in can be found in `/loot-core/src/server/db`
+Much of the interesting functionality you might be interested in can be found in `/loot-core/src/server/db`

--- a/docs/contributing/project-details/index.md
+++ b/docs/contributing/project-details/index.md
@@ -46,7 +46,7 @@ The development version of the importer for nYNAB into Actual.
 
 ### Loot Core
 
-The shared underlying functionality component used by both the web and desktop applications.
+The shared underlying functionality component used by both the web/desktop frontend and the in-browser database server.
 
 ### Node Libofx
 

--- a/docs/contributing/project-details/index.md
+++ b/docs/contributing/project-details/index.md
@@ -46,7 +46,7 @@ The development version of the importer for nYNAB into Actual.
 
 ### Loot Core
 
-### Loot Design
+The shared underlying functionality component used by both the web and desktop applications.
 
 ### Node Libofx
 


### PR DESCRIPTION
- Moved 'The Actual Project Structure' into its own subfolder
- Added a page detailing some info about the database structure of actual
- Removed the reference to 'loot-design' as I think this no longer exists.