### PR TITLE
Add Home Assistant as a community install option

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -25,3 +25,4 @@ Content contained on external links is not managed or maintained by the Actual B
 :::
 
 - [Synology NAS](https://mariushosting.com/how-to-install-actual-on-your-synology-nas/)
+- [Home Assistant](https://github.com/sztupy/hassio-actualbudget/blob/main/README.md)


### PR DESCRIPTION
Home Assistant is an open source home automation framework commonly installed on Raspberry Pi devices as an open source home automation controller.

It has an extensive Add-On package manager allowing people to install various extensions. Actual Budget's architexture makes it a good candidate as an add-on:

* Add-ons are mainly single docker containers, and actual can already run as a single docker container
* It only needs access to `/data` and a single http port to run - ideal condition for HA Add-Ons
* The server is actually only used for syncing, calculations and computational intensive features run on the client machines, so running it would not take away too much resources on limited machines, like the RPi commony used as a HA box

I have made an Add-On repository for Home Assistant that includes both the latest stable and latest edge version of Actual Budget that can be added to Home Assistant to be installed. The repository uses GitHub Actions to keep itself updated whenever new images are pushed to gchr.io as well, so afterwards Home Assisstant can also keep the versions updated automatically.

The add-on already works quite well without any extra steps, but because by default it only runs in unsecured http mode there which is unsupported apart from localhost installations a README was also added to the root to show people how they can use other Home Assitant Add-Ons to run Actual behind a properly set up https proxy.

This change just adds a link to this README allowing people to follow the guides and install Actual on their HA instances