### PR TITLE
Add install docs for Railway.app

### DIFF
--- a/docs-sidebar.js
+++ b/docs-sidebar.js
@@ -95,7 +95,7 @@ const sidebars = {
               type: 'category',
               label: 'In the Cloud',
               collapsible: false,
-              items: ['install/pikapods', 'install/fly'],
+              items: ['install/pikapods', 'install/fly', 'install/railway'],
             },
           ],
         },

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -2,7 +2,7 @@
 title: 'Railway'
 ---
 
-Deploying Actual on Railway is a cheap, no-code solution that can be achieved completely through their dashboard.
+Deploying Actual on Railway is a cheap, no-code solution that can be done completely through their dashboard.
 
 ## Setup
 

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -15,9 +15,9 @@ If you don't already have a Railway account, visit [railway.app](https://railway
 
 From your [Railway dashboard](https://railway.app/dashboard), click `New project` and select `Empty project`.
 
-Click `Add a service`, then select `Docker image`. Enter Actual server's docker image, `actualbudget/actual-server:latest`. Your server will immediately start deploying.
+Click `Add a service`, then select `Docker image`. Enter Actual server's docker image, `actualbudget/actual-server:latest`. Your Actual server will immediately start deploying.
 
-Click `New`, then follow the prompts. There should only be one available service to attach the volume to, and enter `/data` as the mount point.
+Click `New`, then `'volume`. Follow the prompts. There should only be one available service to attach the volume to, and enter `/data` as the mount point.
 
 Click on your service. By default it will have a random name like `future-rock`. In the `variables` tab, create a new variable called `PORT`. Give it a value of `443` for HTTPS (Railway will handle the cert for you).
 

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -2,7 +2,7 @@
 title: 'Railway'
 ---
 
-Deploying Actual on Railway is a cheap, no-code solution that can be done completely through their dashboard.
+Deploying Actual on Railway is a cheap ($5/month), no-code solution that can be done completely through their dashboard.
 
 ## Setup
 

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -17,7 +17,7 @@ From your [Railway dashboard](https://railway.app/dashboard), click `New project
 
 Click `Add a service`, then select `Docker image`. Enter Actual server's docker image, `actualbudget/actual-server:latest`. Your Actual server will immediately start deploying.
 
-Click `New`, then `'volume`. Follow the prompts. There should only be one available service to attach the volume to, and enter `/data` as the mount point.
+Click `New`, then `volume`. Follow the prompts. There should only be one available service to attach the volume to, and enter `/data` as the mount point.
 
 Click on your service. By default it will have a random name like `future-rock`. In the `variables` tab, create a new variable called `PORT`. Give it a value of `443` for HTTPS (Railway will handle the cert for you).
 

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -2,7 +2,7 @@
 title: 'Railway'
 ---
 
-Deploying Actual on Railway is a cheap ($5/month), no-code solution that can be done completely through their dashboard.
+Deploying Actual on Railway is a cheap ($5/month), no-code solution that can be done completely through a dashboard.
 
 ## Setup
 

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -21,6 +21,6 @@ Click `New`, then `volume`. Follow the prompts. There should only be one availab
 
 Click on your service. By default it will have a random name like `future-rock`. In the `variables` tab, create a new variable called `PORT`. Give it a value of `443` for HTTPS (Railway will handle the cert for you).
 
-Then in the `settings` tab, Click `generate domain` if you'd like Railway to create a subdomain for you, otherwise click `Custom Domain` and follow the prompts to add a CNAME record to your domain.
+Then in the `settings` tab, click `Generate Domain` if you'd like Railway to create a subdomain for you, otherwise click `Custom Domain` and follow the prompts to add a CNAME record to your domain.
 
 That's it! Your Actual server will be running on whatever domain you chose, ready for first-time setup.

--- a/docs/install/railway.md
+++ b/docs/install/railway.md
@@ -13,7 +13,7 @@ If you don't already have a Railway account, visit [railway.app](https://railway
 
 ### Installation
 
-From your [Railway dashboard](https://railway.app/dashboard), click `New project` and select 'Empty project'.
+From your [Railway dashboard](https://railway.app/dashboard), click `New project` and select `Empty project`.
 
 Click `Add a service`, then select `Docker image`. Enter Actual server's docker image, `actualbudget/actual-server:latest`. Your server will immediately start deploying.
 


### PR DESCRIPTION
Add install docs for Railway.app, a service similar to Fly.io but a little more non-developer friendly.