### PR TITLE
Update ynab4 + 5 importer links in api docs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -87,7 +87,7 @@ This is very simple, but it takes some data in `my-data.json` and creates all th
 
 **Note:** it's important that [`addTransactions`](./reference.md#addtransactions) is used here. You want to use it instead of [`importTransactions`](./reference.md#importtransactions) when dumping raw data into Actual. The former will not run the reconciliation process (which dedupes transactions), and won't create the other side of transfer transactions, and more. If you use `importTransactions` it may adjust your data in ways that don't match the data you’re importing.
 
-Check out the [YNAB4](https://github.com/actualbudget/actual/blob/master/packages/import-ynab4/importer.js) and [YNAB5](https://github.com/actualbudget/actual/blob/master/packages/import-ynab5/importer.js) importers to see how a real importer works.
+Check out the [YNAB4](https://github.com/actualbudget/actual/blob/master/packages/loot-core/src/server/importers/ynab4.ts) and [YNAB5](https://github.com/actualbudget/actual/blob/master/packages/loot-core/src/server/importers/ynab5.ts) importers to see how a real importer works.
 
 ## Methods
 


### PR DESCRIPTION
So they point to existing implementations. The current links are broken and Im hoping these links are correct - someone please let me know if this is incorrect, thanks