### PR TITLE
📝 (reverse proxies) Remove duplicate line, add service port for Traefik

### DIFF
--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -73,9 +73,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.actual-server.rule=Host(`budget.example.org`)"
       - "traefik.http.routers.actual-server.entrypoints=websecure"
+      - "traefik.http.services.actual-server.loadbalancer.server.port=5006"
     volumes:
       - ./actual-data:/data
-    restart: unless-stopped
 ```
 
 ```yaml title="traefik.yaml"


### PR DESCRIPTION
While deploying with Traefik I found two small errors in the documentation. 
First is the duplicate line, the second is the missing line so that Traefik knows on which port it should send the traffic to. 