### PR TITLE
Added VM specification to `fly.toml` to keep within Fly.io free allowances

### DIFF
--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -148,6 +148,11 @@ Now that you’ve gotten the CLI set up, you’re ready to deploy your app to Fl
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256 
 ```
 
 </details>

--- a/static/fly.toml
+++ b/static/fly.toml
@@ -36,3 +36,9 @@
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256 
+  


### PR DESCRIPTION
# Motivation
Fly.io default resource allocation spins up a machine with 1GB of RAM, which is outside the free usage allowance.

Added VM specification to `fly.toml` file to prevent inadvertent billing.

# References
* [Fly.io - VM specification](https://fly.io/docs/reference/configuration/#the-vm-section)
* [Fly.io - Free allowances](https://fly.io/docs/about/pricing/#free-allowances)
