### PR TITLE
cautionary notice about new Fly pricing

### DIFF
--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -9,19 +9,17 @@ In order to deploy Actual to Fly.io, you’ll need to use their command line int
 ### Creating a Fly.io Account
 
 :::caution
-At the time of writing (2024-02-06), the Fly's new pricing structure is unclear. On the one hand, they've updated their docs, which states that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
+At the time of writing (2024-02-06), Fly's new pricing structure is not clearly communicated.
+They've updated their docs, which state that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
+However, as [clarified by Fly staff](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/8?u=tjex) on the Fly forum, new accounts are indeed charged $5 per month + any usage that exceeds the free allowances.
 
-However, as discussed in [this thread](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/5) a user has complained that they were *debited* $5 on the creation of a new account.
+This means it is no longer possible to use Fly for free within the "free allowance" limits. There is now a base $5 fee per month. Any usage outside the "free allowance" is billed accordingly ontop of the monthly $5 fee.
 
-We're waiting on some extra clarification from Fly at this point as to what exactly the situation is regarding new account pricing and discussing it [here](https://github.com/actualbudget/docs/issues/296).
-
-If you're concerned about the ambiguity of this, you can still move ahead with installing and working with Actual Budget by starting a [local installation](local) and hosting with Fly after this confusion has been cleared up.
+See [Fly's pricing page](https://fly.io/docs/about/pricing/#new-customers) for further details.
 :::
 
-First, you’ll need to sign up for an account. Go to [fly.io](https://fly.io) and
-click “Get Started,” then fill in the form. Note that Fly requires that credit
-card details for sign up. See [their docs on how they use credit
-cards](https://fly.io/docs/about/credit-cards/) for more information.
+To begin, you’ll need to sign up for an account. Go to [fly.io](https://fly.io) and click “Get Started,” then fill in
+the form. Note that Fly requires that credit card details for sign up. See [their docs on how they use credit cards](https://fly.io/docs/about/credit-cards/) for more information.
 
 ### Accessing the `fly` command line tool
 

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -8,14 +8,15 @@ In order to deploy Actual to Fly.io, you’ll need to use their command line int
 
 ### Creating a Fly.io Account
 
-:::caution
-At the time of writing (2024-02-06), Fly's new pricing structure is not clearly communicated.
-They've updated their docs, which state that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
-However, as [clarified by Fly staff](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/8?u=tjex) on the Fly forum, new accounts are indeed charged $5 per month + any usage that exceeds the free allowances.
+:::note
+Fly's pricing structure has changed as of Jan 25, 2024.
+New accounts are now gifted $5 credit. That $5 credit is only spent when exceeding the [free allowances](https://fly.io/docs/about/pricing/#free-allowances) for apps.
+This is called the 'Hobby Trial' plan.
 
-This means it is no longer possible to use Fly for free within the "free allowance" limits. There is now a base $5 fee per month. Any usage outside the "free allowance" is billed accordingly on top of the monthly $5 fee.
+If you create an *additional* organisation from an existing account on a 'Hobby Trial' plan, that organisation will directly start on the 'Hobby' plan, which costs $5 per month as a base rate + usage outside of the free allowance limits.
+This has been confirmed by [Fly staff via their forum](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/8?u=tjex).
 
-See [Fly's pricing page](https://fly.io/docs/about/pricing/#new-customers) for further details.
+You can therefore still sign up and host your Actual Budget instance with Fly for free, as the usage will not exceed the free allowances.
 :::
 
 To begin, you’ll need to sign up for an account. Go to [fly.io](https://fly.io) and click “Get Started,” then fill in

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -9,7 +9,7 @@ In order to deploy Actual to Fly.io, you’ll need to use their command line int
 ### Creating a Fly.io Account
 
 :::caution
-At the time of writing (2024-02-06), the Fly's new pricing structure is unclear. On the one hand, they've udpated their docs, which states that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
+At the time of writing (2024-02-06), the Fly's new pricing structure is unclear. On the one hand, they've updated their docs, which states that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
 
 However, as discussed in [this thread](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/5) a user has complained that they were *debited* $5 on the creation of a new account.
 

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -8,7 +8,20 @@ In order to deploy Actual to Fly.io, you’ll need to use their command line int
 
 ### Creating a Fly.io Account
 
-First, you’ll need to sign up for an account. Go to [fly.io](https://fly.io) and click “Get Started,” then fill in the form. Note that Fly may require you to enter credit card details. See [their docs on how they use credit cards](https://fly.io/docs/about/credit-cards/) for more information. If you follow the steps in this guide, you will remain well within the free plan limits. For more details, check out [Fly’s pricing documentation](https://fly.io/docs/about/pricing/).
+:::caution
+At the time of writing (2024-02-06), the Fly's new pricing structure is unclear. On the one hand, they've udpated their docs, which states that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
+
+However, as discussed in [this thread](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/5) a user has complained that they were *debited* $5 on the creation of a new account.
+
+We're waiting on some extra clarification from Fly at this point as to what exactly the situation is regarding new account pricing and discussing it [here](https://github.com/actualbudget/docs/issues/296).
+
+If you're concerned about the ambiguity of this, you can still move ahead with installing and working with Actual Budget by starting a [local installation](local) and hosting with Fly after this confusion has been cleared up.
+:::
+
+First, you’ll need to sign up for an account. Go to [fly.io](https://fly.io) and
+click “Get Started,” then fill in the form. Note that Fly requires that credit
+card details for sign up. See [their docs on how they use credit
+cards](https://fly.io/docs/about/credit-cards/) for more information.
 
 ### Accessing the `fly` command line tool
 

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -13,7 +13,7 @@ At the time of writing (2024-02-06), Fly's new pricing structure is not clearly 
 They've updated their docs, which state that [new customers are *credited* $5, so they can try Fly at *no cost*](https://fly.io/docs/about/pricing/#new-customers).
 However, as [clarified by Fly staff](https://community.fly.io/t/i-got-charged-today-for-the-hobby-plan-and-im-confused-as-to-why-cause-fly-io-didnt-send-any-emails/17969/8?u=tjex) on the Fly forum, new accounts are indeed charged $5 per month + any usage that exceeds the free allowances.
 
-This means it is no longer possible to use Fly for free within the "free allowance" limits. There is now a base $5 fee per month. Any usage outside the "free allowance" is billed accordingly ontop of the monthly $5 fee.
+This means it is no longer possible to use Fly for free within the "free allowance" limits. There is now a base $5 fee per month. Any usage outside the "free allowance" is billed accordingly on top of the monthly $5 fee.
 
 See [Fly's pricing page](https://fly.io/docs/about/pricing/#new-customers) for further details.
 :::


### PR DESCRIPTION
As discussed in [#296](https://github.com/actualbudget/docs/issues/296) the new
pricing structure of Fly is confusing and not being communicated well.

This PR puts up a temporary notice explaining this, so that new users are
informed and won't get slugged with an surprise $5 charge (if that is indeed the
case... 🤷).

It also offers a temporary solution to move ahead with a local install, which
can then be pushed to Fly later on. So new users won't just hit a dead end
either.
