### PR TITLE
Capitalize "actual" on line 7

### DIFF
--- a/docs/contributing/project-details/database.md
+++ b/docs/contributing/project-details/database.md
@@ -4,6 +4,6 @@ Actual stores your data locally inside a sqlite database. You can see the defaul
 
 However this is not the 'current' structure, as the database is created as a copy from the default template, and then a series of migrations is run to get the database up to the current level. You can see these migrations in `/loot-core/migrations`.
 
-On the front end, actual sometimes uses views to display data. All the names with the `v_` prefix are actually views, not tables. The views are recreated every time the app starts and normalize the shape of the data to the internal tables. Makes it easy to change field names etc without actually touching the tables (especially important in this local-first world where syncing directly references tables and fields)
+On the front end, Actual sometimes uses views to display data. All the names with the `v_` prefix are actually views, not tables. The views are recreated every time the app starts and normalize the shape of the data to the internal tables. Makes it easy to change field names etc without actually touching the tables (especially important in this local-first world where syncing directly references tables and fields)
 
 Much of the interesting functionality you might be interested in can be found in `/loot-core/src/server/db`


### PR DESCRIPTION
Incredibly minor change. I'm assuming this aligns to the brand template as I saw "Actual" (capitalized) elsewhere.