### PR TITLE
Add actual-tap to community repos page

### DIFF
--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -15,3 +15,4 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
 
 ## Others
 * **Local REST api** - https://github.com/jhonderson/actual-http-api
+* **Auto post tap to pay** - https://github.com/MattFaz/actual-tap


### PR DESCRIPTION
This is an api usage that auto posts tap to pay transactions via some phone automations and a docker project.