### PR TITLE
fix: Open Collective link

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -278,7 +278,7 @@ export default function Hello() {
             their servers to{' '}
             <a
               style={{ color: 'inherit', textDecoration: 'underline' }}
-              href="https://opencollective.org/actual"
+              href="https://opencollective.com/actual"
             >
               our Open Collective
             </a>


### PR DESCRIPTION
Changes the Open Collective URL from `.org` to `.com` (the `.org` is not accessible).