### PR TITLE
Remove web terminal section from Fly.io docs

### DIFF
--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -24,28 +24,7 @@ the form. Note that Fly requires that credit card details for sign up. See [thei
 
 ### Accessing the `fly` command line tool
 
-There are two ways to access the `fly` command line tool. You can either install it on your local machine, or you can use the web-based terminal that Fly provides. We recommend using the web-based terminal, as it’s the easiest way to get started. However, if you run into issues with the web-based terminal, you can always install the `fly` command line tool on your local machine.
-
-#### Web-based terminal
-
-Go to https://fly.io/terminal/ and click “Launch Web CLI” at the bottom of the page. You may be asked to log into Fly.
-
-Create a new folder named `actual` by typing in this command once the `/app/bin $` prompt appears. Once you’ve typed in the command, press the `Enter` key on your keyboard.
-
-```
-mkdir actual; cd actual
-```
-
-Your terminal should look like this if you’ve done everything correctly:
-
-```
-/app/bin $ mkdir actual; cd actual
-/app/bin/actual $
-```
-
-#### Local installation
-
-If you prefer to install the `fly` command line tool on your local machine, you’ll need to start by opening a command line terminal on your computer.
+To install the `fly` command line tool on your local machine, you’ll need to start by opening a command line terminal on your computer.
 
 - **Windows**: Open the Start menu and search for “PowerShell.” Click on the “PowerShell” app to open it.
 - **macOS**: Open the “Terminal” app from the Utilities folder in your Applications folder.
@@ -111,63 +90,6 @@ Type `fly auth login` and press enter to open your browser and log your terminal
 ## Configuring the app
 
 Now that you’ve gotten the CLI set up, you’re ready to deploy your app to Fly.io. First, you’ll need our template Fly configuration:
-
-### Web-based terminal
-
-1. Type in (or copy-paste) the command `cat > fly.toml` and press enter. Your cursor should move to a new blank line.
-2. Copy the contents of the `fly.toml` template file below and paste it into the terminal.
-3. Hit return on your keyboard so your cursor is at the beginning of a new line.
-4. Press control+d on your keyboard to save the file. (Use the “control” key even on macOS! Terminals are weird)
-
-<details><summary>Click to expand <code>fly.toml</code> template</summary>
-
-```toml title=fly.toml
-[env]
-  PORT = "5006"
-  TINI_SUBREAPER = "1"
-
-[experimental]
-  auto_rollback = true
-  cmd = ["node", "--max-old-space-size=180", "app.js"]
-
-[mounts]
-  source="actual_data"
-  destination="/data"
-
-[[services]]
-  http_checks = []
-  internal_port = 5006
-  processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
-
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
-
-  [[services.tcp_checks]]
-    grace_period = "10s"
-    interval = "15s"
-    restart_limit = 0
-    timeout = "2s"
-
-[[vm]]
-  cpu_kind = "shared"
-  cpus = 1
-  memory_mb = 256 
-```
-
-</details>
 
 ### Local terminal
 
@@ -266,22 +188,6 @@ Actual is now up and running. Congratulations! Consider checking out [our tour](
 ## Updating Actual
 
 When updates to Actual are released, you’ll need to re-deploy your app to get the latest version.
-
-### Web-based terminal
-
-Go to https://fly.io/terminal/ and click “Launch Web CLI” at the bottom of the page. You may be asked to log into Fly.
-
-Run the following command, changing the `your-app-name` part to the name you chose when you first deployed Actual:
-
-```bash
-fly deploy --image actualbudget/actual-server:latest --app your-app-name
-```
-
-For example, if your copy of Actual was available at `https://spring-firefly-8368.fly.dev/`, you would run:
-
-```bash
-fly deploy --image actualbudget/actual-server:latest --app spring-firefly-8368
-```
 
 ### Local terminal
 


### PR DESCRIPTION
The web terminal is no longer available on Fly.io and has caused a bit of confusion for folks who are trying to get Actual deployed.