### PR TITLE
fix links in the ynab blog

### DIFF
--- a/blog/2024-07-01-ynab_v_actual.md
+++ b/blog/2024-07-01-ynab_v_actual.md
@@ -21,7 +21,7 @@ Lets see how Actual stacks up!
 I will structure this comparison as follows.
 First I will go over some of the fundamentals individually, then at the end have a quick comparison of some of the smaller features.
 I will go in depth in the basics like how Actual is installed and run, how the budgeting basics compare, and then the other exciting features.
-Along with this blog post you can look around at our [documentation](../docs), or our [main feature list](../#features).
+Along with this blog post you can look around at our [documentation](../../docs), or our [main feature list](../../#features).
 
 ### tl;dr
 * Actual uses **envelope budgeting**, same as YNAB.
@@ -70,8 +70,8 @@ This can be found in your browser settings when viewing the web page.
 
 Actual has two parts: the client (the stuff you see and interact with), and an optional sync server.
 The server is what allows syncing your budget file between devices and allows for bank syncing.
-A full list of what does and does not require the sync server can be found [in this table](../docs/install).
-The [docs page](../docs/install/) also includes information about options for hosting a sync server.
+A full list of what does and does not require the sync server can be found [in this table](../../docs/install).
+The [docs page](../../docs/install) also includes information about options for hosting a sync server.
 
 The quickest way to host a sync server is [to use PikaPods](https://www.pikapods.com/pods?run=actual).
 PikaPods is a hosting service that costs just over one dollar a month to host a personal sync server[^1].
@@ -84,7 +84,7 @@ Other options include hosting your own with docker or node.js, or using some oth
 The core budgeting style is where Actual and YNAB are the most similar.
 Both use envelope style budgeting, sometimes referred to zero-sum budgeting.
 This means that all your funds are assigned to categories, or "jobs" in YNAB vernacular.
-The budgeting styles are so similar you can [import your YNAB data into Actual](../docs/migration/nynab) and move on like almost nothing changed.
+The budgeting styles are so similar you can [import your YNAB data into Actual](../../docs/migration) and move on like almost nothing changed.
 
 How accounts and transactions are handled is very similar.  There are transactions with payees, notes, categories, etc.
 Just like you are used to.
@@ -101,7 +101,7 @@ Some users prefer this approach while others find it annoying.
 
 The way YNAB handles this can make it a bit too easy to hold onto credit card debt and let it build up.
 Actual needs some more deliberate handling of that debt.
-Our docs [show how to do this in Actual](../docs/budgeting/credit-cards).
+Our docs [show how to do this in Actual](../../docs/budgeting/credit-cards).
 The tl;dr is that you put your existing debt in a category on your budget and any new debt has to be manually added into that category.
 Principal and interest payments, get categorized into this category.
 If you use credit cards, but don't carry any debt, the don't worry, you don't have to do anything special.
@@ -144,7 +144,7 @@ YNAB does also have indicator bars to show if the goal has been met, or progress
 
 Actual currently is developing a feature that is similar to YNAB's targets we refer to as goal templates. 
 Goal templates is more flexible and has more options than YNAB's targets.
-A full write up of how they work can be found in the [Goal Templates Documentation](../docs/experimental/goal-templates).
+A full write up of how they work can be found in the [Goal Templates Documentation](../../docs/experimental/goal-templates).
 Some notable goals that Actual has would be: goals based on scheduled expenses, percentage goals, remainder goals, and much more!
 
 One big difference from YNAB to Actual currently is that in Actual goals are indicated as met or not on a monthly basis instead of a total basis.
@@ -158,14 +158,14 @@ These goals can also be used to automate your budgeting each month, same as YNAB
 One extra feature that YNAB does not have with their goals is the ability to prioritize certain categories.
 This makes it so the goal templates can be used to budget everything automatically.
 There are a few blog posts about using these templates.
-One about budgeting all [categories using priorities](./2023-12-15-automate-your-budget-with-goal-templates).
-And another for [weekly based budgeting](./2024-03-25-goal-templates-with-a-twist).
+One about budgeting all [categories using priorities](./2023-12-15-automate.md).
+And another for [weekly based budgeting](./2024-03-25-automate-twist.md).
 
 Goal templates is under active development so expect it to be even better as time goes on!
 
 ### Other Features
 
-This will be a rapid fire view of feature comparison.  For a full view of these features you can read up [in our documentation](../docs/).
+This will be a rapid fire view of feature comparison.  For a full view of these features you can read up [in our documentation](../../docs).
 Don't worry the docs aren't too long to read. I will also be including the already mentioned features.
 
 |Feature | Actual | YNAB | Notes |


### PR DESCRIPTION
since the link paths are treated differently depending on if the blog is directly linked to vs navigated to.  I believe these links will always work