### PR TITLE
Add reference to the Python library

### DIFF
--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -21,3 +21,5 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
    - *Categorise transactions using AI*
 * **Actual Helpers** - https://github.com/psybers/actual-helpers
    - *Collection of helper scripts to do things like track home prices, car values, add loan interest transactions, track investment accounts, etc.*
+* **Python API** - https://github.com/bvanelli/actualpy
+   - *API to interact with the Actual server, written in Python.*

--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -21,5 +21,5 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
    - *Categorise transactions using AI*
 * **Actual Helpers** - https://github.com/psybers/actual-helpers
    - *Collection of helper scripts to do things like track home prices, car values, add loan interest transactions, track investment accounts, etc.*
-* **Python API** - https://github.com/bvanelli/actualpy
+* **Actual Python API** - https://github.com/bvanelli/actualpy
    - *API to interact with the Actual server, written in Python.*


### PR DESCRIPTION
Adds the link to the Python library I wrote for actual called [actualpy](https://github.com/bvanelli/actualpy) to the list of community projects. It's also released [on Pip](https://pypi.org/project/actualpy/).

Library implements the core functionality of most of the original API, by a mix of reverse-engineering the UI calls and the checking the source code.

Experimental features cover bank syncs, schedules and rules.