### PR TITLE
Add web app install docs

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -40,6 +40,20 @@ Once you’ve set up your server, you can [configure it](../config/index.md) to 
 
 If you're coming from the original, managed Actual subscription service, you may want to [migrate your data](../migration/index.md).
 
+## Server-Free Web App
+
+If you are okay with not having sync or auto-save or backups then the easiest and fastest way to get started is by using the Actual [web app](https://app.actualbudget.org). There's less setup involved in this solution but more maintenance. 
+
+All data is saved to your local browser. The Actual web app never has access to any of your personal data. It is recommended that you save your data (from the [settings](../backup-restore/backup) menu) after every session. If your browser memory is cleared then your data will be lost so having a backup is crucial. 
+
+Using a new device or a new browser requires you to [import](../migration/actual-import#import-backup-file) the saved file for each new device or browser. Keep in mind that these new devices and browsers will not sync without a server set up, so anything you modify on one browser will not show up on any others.
+
+:::caution
+
+This solution is not recommended for long-term use due to the maintenance required and the high probability of data loss. It's intended as a quick start, if you'd like to continue using Actual long-term, please use one of the server options above.
+
+:::
+
 ## Additional Installation Options
 
 In addition to our officially supported options listed above, some community members have written guides for using other platforms or tools:

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -25,7 +25,7 @@ Using a new device or browser requires you to [import](../migration/actual-impor
 
 :::caution
 
-This solution is not recommended for long-term use due to the maintenance required and the high probability of data loss. It's intended as a quick start. If you'd like to continue using Actual long-term, please use one of the server options below.
+This solution is not recommended for long-term use due to the maintenance required and the high probability of data loss. It's intended as a quick start. If you'd like to continue using Actual long-term, please use one of the server options [below](#running-a-server).
 
 :::
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -15,6 +15,20 @@ The Actual Budget project is made up of two parts: the client and the server.  A
 
 The standard way of using Actual is to set up a personal server and use a web browser for the application.  For quick testing or getting to know Actual before setting up a server, the [demo](https://demo.actualbudget.org) or a [desktop application](https://github.com/actualbudget/actual/releases) are a good place to start.
 
+## Using Actual locally in the browser
+
+If you are okay with not having sync, auto-save, or backups then the easiest and fastest way to get started is by using the Actual [web app](https://app.actualbudget.org). This solution requires less setup but more maintenance. 
+
+All data is saved to your local browser. The Actual web app never has access to any of your personal data. It is recommended that you save your data (from the [settings](../backup-restore/backup) menu) after every session. If your browser memory is cleared, your data will be lost, so a backup is crucial. 
+
+Using a new device or browser requires you to [import](../migration/actual-import#import-backup-file) the saved file for each new device or browser. Remember that these new devices and browsers will not sync without a server set up, so anything you modify on one browser will not appear on others.
+
+:::caution
+
+This solution is not recommended for long-term use due to the maintenance required and the high probability of data loss. It's intended as a quick start. If you'd like to continue using Actual long-term, please use one of the server options below.
+
+:::
+
 ## Server-Optional Client Options
 
 Desktop applications are available for Windows, Mac, and Linux. These can be [downloaded from GitHub](https://github.com/actualbudget/actual/releases).  The desktop apps have the following benefits:
@@ -39,20 +53,6 @@ While running a server can be a complicated endeavour, we’ve tried to make it 
 Once you’ve set up your server, you can [configure it](../config/index.md) to change a few of the ways it works.
 
 If you're coming from the original, managed Actual subscription service, you may want to [migrate your data](../migration/index.md).
-
-## Server-Free Web App
-
-If you are okay with not having sync or auto-save or backups then the easiest and fastest way to get started is by using the Actual [web app](https://app.actualbudget.org). There's less setup involved in this solution but more maintenance. 
-
-All data is saved to your local browser. The Actual web app never has access to any of your personal data. It is recommended that you save your data (from the [settings](../backup-restore/backup) menu) after every session. If your browser memory is cleared then your data will be lost so having a backup is crucial. 
-
-Using a new device or a new browser requires you to [import](../migration/actual-import#import-backup-file) the saved file for each new device or browser. Keep in mind that these new devices and browsers will not sync without a server set up, so anything you modify on one browser will not show up on any others.
-
-:::caution
-
-This solution is not recommended for long-term use due to the maintenance required and the high probability of data loss. It's intended as a quick start, if you'd like to continue using Actual long-term, please use one of the server options above.
-
-:::
 
 ## Additional Installation Options
 


### PR DESCRIPTION
Adding a section to install documentation that explains how one could use the web app for a quick start without sync.