### PR TITLE
Update fly.io pricing information

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -32,7 +32,7 @@ While running a server can be a complicated endeavour, we’ve tried to make it 
 
 - If you’re not comfortable with the command line and are willing to pay a small amount of money to have your version of Actual hosted on the cloud for you, we recommend [PikaPods](pikapods.md).[^2]
 - If you’re willing to run a few commands in the terminal:
-  - [Fly.io](fly.md) offers free cloud hosting.
+  - [Fly.io](fly.md) also offers cloud hosting for a similar amount of money.
   - You could [directly install Actual locally](local.md) on macOS, Windows, or Linux if you don’t want to use a tool like Docker. (This method is the best option if you want to contribute to Actual's development!)
   - If you want to use Docker, we have instructions for [using our provided Docker containers](docker.md).
 


### PR DESCRIPTION
Fly.io no longer offers free cloud hosting; it is pay as you go with actual usage billed monthly. I calculated between Pikapods $1.4 per month and Fly.io's $1.5 per month and chose Pikapods since it's one click and it's cheaper. If there's anything wrong in my calculations, please let me know.