### PR TITLE
[WIP] GoCardless clarification on number of requests on the free tier + alt-text of images + fix a step number

### DIFF
--- a/docs/advanced/bank-sync.md
+++ b/docs/advanced/bank-sync.md
@@ -21,39 +21,47 @@ We are excited to offer this optional bank integration in Actual. Here are a cou
 
 ## GoCardless Setup
 
-**Create SECRET and KEY for Actual**
+### Create SECRET and KEY for Actual
 
 1. Create an account with GoCardless - https://bankaccountdata.gocardless.com/overview/
 2. Log into your account dashboard at the same URL and select **Developers->User secrets** from the left side menu
 
-![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-01.png)
+![Screenshot of GoCardless developer portal](/static/img/connecting-your-bank/connecting-your-bank-gocardless-01.png)
+
 
 3. Click on the '+ create new' button at the bottom left.
    - Make sure you download your secrets file since the **key** will not be available to you again in the account dashboard
    - These secrets will be used in Actual to make the bank sync connection
 
-![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-02.png)
+![Screenshot of GoCardless page for creating API secrets](/static/img/connecting-your-bank/connecting-your-bank-gocardless-02.png)
+
 
 4. Enter a name for your secrets and click Create.
    _This is only for you to easily identify them in the GoCardless User secrets overview_
 
-![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-03.png)
+![Screenshot of GoCardless form for creating new API secret](/static/img/connecting-your-bank/connecting-your-bank-gocardless-03.png)
+
 
 5. Download this file and keep it on your computer.
 
-![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-04.png)
+![Screenshot of GoCardless API secret after successful creation](/static/img/connecting-your-bank/connecting-your-bank-gocardless-04.png)
+
+
 
 6. Back in Actual, click on “+ Add account” at the bottom of the sidebar.
 
-   ![](/static/img/connecting-your-bank/connecting-your-bank-02.png)
+![Actual sidebar with accounts](/static/img/connecting-your-bank/connecting-your-bank-02.png)
+
+
 
 7. Click “Set-up GoCardless for bank-sync.”
 
-   ![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-05.png)
+![Add account dialog](/static/img/connecting-your-bank/connecting-your-bank-gocardless-05.png)
 
 8. You will be asked to enter your GoCardless secret ID and secret key. These values will be saved on the server, so you will only need to enter them once.
 
-   ![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-06.png)
+![Set-up GoCardless dialoag](/static/img/connecting-your-bank/connecting-your-bank-gocardless-06.png)
+
 
 ### Link Accounts with GoCardless
 
@@ -61,43 +69,43 @@ We are excited to offer this optional bank integration in Actual. Here are a cou
 
    - **_For an existing account, click on that account, select the ... (kebab menu) in the top right, and choose Link Account_**
 
-   ![](/static/img/connecting-your-bank/connecting-your-bank-01.png)
+![Linking an existing account to GoCardless](/static/img/connecting-your-bank/connecting-your-bank-01.png)
 
    - **_To create a new account with bank syncing click on the '+ Add account' link in the left menu at the bottom_**
 
-   ![](/static/img/connecting-your-bank/connecting-your-bank-02.png)
+![Actual sidebar with accounts](/static/img/connecting-your-bank/connecting-your-bank-02.png)
 
 2. Select the Link your bank account button
 
-![](/static/img/connecting-your-bank/connecting-your-bank-03.png)
+![Add acount dialog](/static/img/connecting-your-bank/connecting-your-bank-03.png)
 
 3. Select your country and bank from the list and click the Link bank in browser button
 
-![](/static/img/connecting-your-bank/connecting-your-bank-04.png)
+![Link your bank dialog](/static/img/connecting-your-bank/connecting-your-bank-04.png)
 
 4. Clicking Link bank in browser will redirect you to a new tab to grant access to your bank for GoCardless
 
-![](/static/img/connecting-your-bank/connecting-your-bank-05.png)
+![Link you bank feedback](/static/img/connecting-your-bank/connecting-your-bank-05.png)
 
 5. Select **I agree** to continue with setting up the connection
 
-![](/static/img/connecting-your-bank/connecting-your-bank-gocardless-07.png)
+![Dialog to approve that GoCardless will be accessing your payment account information](/static/img/connecting-your-bank/connecting-your-bank-gocardless-07.png)
 
 6. If your connection was a success, you will be able to click on the continue button which allows GoCardless to connect
 
-![](/static/img/connecting-your-bank/connecting-your-bank-07.png)
+![Feedback for successful linking to your bank](/static/img/connecting-your-bank/connecting-your-bank-07.png)
 
 7. A progress indicator will display while GoCardless connects to your bank to get a list of your accounts
 
-![](/static/img/connecting-your-bank/connecting-your-bank-08.png)
+![Dialog saying please wait while we finish linking your account(s).](/static/img/connecting-your-bank/connecting-your-bank-08.png)
 
 8. Once the connection has been made, there will be a list of your accounts that you can choose from
 
-![](/static/img/connecting-your-bank/connecting-your-bank-09.png)
+![Select bank acount you want to link](/static/img/connecting-your-bank/connecting-your-bank-09.png)
 
-7. The final step is to select the account you want to sync and click Link account
+9. The final step is to select the account you want to sync and click Link account
 
-![](/static/img/connecting-your-bank/connecting-your-bank-10.png)
+![Dialog for linking accounts you want to sync](/static/img/connecting-your-bank/connecting-your-bank-10.png)
 
 ### Frequently Asked Questions
 
@@ -105,7 +113,7 @@ We are excited to offer this optional bank integration in Actual. Here are a cou
 
 At this moment, it is not yet possible for Actual to automatically sync with your bank. You need to do this manually by going to "All Accounts" and pressing "Sync".
 
-![](/static/img/connecting-your-bank/syncing-with-your-bank.png)
+![Image showing where in the GUI you can sync your bank accounts](/static/img/connecting-your-bank/syncing-with-your-bank.png)
 
 **The best way to start from scratch in Actual with Go Cardless?**
 

--- a/docs/advanced/bank-sync.md
+++ b/docs/advanced/bank-sync.md
@@ -15,11 +15,11 @@ We are excited to offer this optional bank integration in Actual. Here are a cou
 
 - You will need to add a config file to your installation
 
-### Supported Providers
+## Supported Providers
 
-GoCardless
+* GoCardless
 
-### GoCardless Setup
+## GoCardless Setup
 
 **Create SECRET and KEY for Actual**
 
@@ -113,3 +113,10 @@ If you are setting up Actual for the first time, it is much easier not to try to
 1. Set up your account in Actual specifying a correct opening account balance at a recent date.
 2. Link the account to Go Cardless as above
 3. Sync the account with Go Cardless. You should find that only transactions subsequent to the opening account balance entry are imported, making reconciliation easy.
+
+
+**How many times can I sync with  Go Cardless?**
+In the free tier, you can sync 50 times per month. If you sync to two different banks (with three accounts in each bank), that is counted as two connections.
+For more information, see the [Bank Account Data API Usage](https://bankaccountdata.zendesk.com/hc/en-gb/articles/11528933493916-Bank-Account-Data-API-Usage-how-is-your-usage-number-calculated)
+topic in the GoCardless FAQ.
+

--- a/docs/advanced/bank-sync.md
+++ b/docs/advanced/bank-sync.md
@@ -5,7 +5,8 @@ Client Version 23.7.0 and
 Server Version 23.7.0 or higher are required for this feature.
 :::
 
-We are excited to offer this optional bank integration in Actual. Here are a couple of considerations to know about before making the decision to use bank sync in your installation of Actual Budget.
+We are excited to offer this optional bank integration in Actual. 
+Here are a couple of considerations to know about before making the decision to use bank sync in your installation of Actual Budget.
 
 - This integration relies on you providing your own API credentials that you will need to get by signing up with the service provider and Generate Keys and Secrets that will be used in Actual.
 
@@ -115,15 +116,15 @@ At this moment, it is not yet possible for Actual to automatically sync with you
 
 ![Image showing where in the GUI you can sync your bank accounts](/static/img/connecting-your-bank/syncing-with-your-bank.png)
 
-**The best way to start from scratch in Actual with Go Cardless?**
+**The best way to start from scratch in Actual with GoCardless?**
 
 If you are setting up Actual for the first time, it is much easier not to try to pull in historic data. This has caused some users a lot of headaches with subsequent reconciliation. The following process may be more helpful:
 1. Set up your account in Actual specifying a correct opening account balance at a recent date.
-2. Link the account to Go Cardless as above
-3. Sync the account with Go Cardless. You should find that only transactions subsequent to the opening account balance entry are imported, making reconciliation easy.
+2. Link the account to GoCardless as above
+3. Sync the account with GoCardless. You should find that only transactions subsequent to the opening account balance entry are imported, making reconciliation easy.
 
 
-**How many times can I sync with  Go Cardless?**
+**How many times can I sync with  GoCardless?**
 In the free tier, you can sync 50 times per month. If you sync to two different banks (with three accounts in each bank), that is counted as two connections.
 For more information, see the [Bank Account Data API Usage](https://bankaccountdata.zendesk.com/hc/en-gb/articles/11528933493916-Bank-Account-Data-API-Usage-how-is-your-usage-number-calculated)
 topic in the GoCardless FAQ.


### PR DESCRIPTION
1. Added information about the number of syncs on the free tier (which is 50).
2. Added link to documentation on how GoCardless counts connections.
3. Added alt-text to all images.
4. Fixed a typo in one of the numeration of the steps in how to link a GoCardless account to AB - step 8 was repeated twice.