### PR TITLE
Update Mac links on Downloads page 

### DIFF
--- a/src/pages/download.md
+++ b/src/pages/download.md
@@ -13,9 +13,9 @@ The simplest way to use Actual is to download the desktop application.  This wil
 
 ## Desktop Client
 |||
-|:--:|:--:|:--:|:--:|
-|<Winsvg width="100" height="100" fill="#6B46C1"/>|<Macsvg width="100" height="105" fill="#6B46C1"/>|<Linuxsvg width="100" height="100" fill="#6B46C1" />|<Linuxsvg width="100" height="100" fill="#6B46C1"/>|
-|[Windows](https://github.com/actualbudget/actual/releases/latest/download/Actual-windows.exe)|[Mac](https://github.com/actualbudget/actual/releases/latest/download/Actual-mac.dmg)|[Linux (Appimage)](https://github.com/actualbudget/actual/releases/latest/download/Actual-linux.AppImage)|[Linux (Flatpak) ](https://github.com/actualbudget/actual/releases/latest/download/Actual-linux.flatpak)|
+|:--:|:--:|:--:|:--:|:--:|
+|<Winsvg width="100" height="100" fill="#6B46C1"/>|<Macsvg width="100" height="105" fill="#6B46C1"/>|<Macsvg width="100" height="105" fill="#6B46C1"/>|<Linuxsvg width="100" height="100" fill="#6B46C1" />|<Linuxsvg width="100" height="100" fill="#6B46C1"/>|
+|[Windows](https://github.com/actualbudget/actual/releases/latest/download/Actual-windows.exe)|[Mac (x64)](https://github.com/actualbudget/actual/releases/latest/download/Actual-mac-x64.dmg)|[Mac (arm64)](https://github.com/actualbudget/actual/releases/latest/download/Actual-mac-arm64.dmg)|[Linux (Appimage)](https://github.com/actualbudget/actual/releases/latest/download/Actual-linux.AppImage)|[Linux (Flatpak) ](https://github.com/actualbudget/actual/releases/latest/download/Actual-linux.flatpak)|
 
 
 ## Server Download


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/85059ade-8d5f-433c-9fb0-d2455743da4b)

**Possible improvement for later:** we could detect the OS the user is using and filter the list down so there aren't so many options.
