### PR TITLE
Make note/link about SimpleFIN in the bank docs page.

### DIFF
--- a/docs/advanced/bank-sync.md
+++ b/docs/advanced/bank-sync.md
@@ -20,6 +20,10 @@ Here are a couple of considerations to know about before making the decision to 
 
 * GoCardless
 
+:::note
+[Experimental support for SimpleFIN](../experimental/simplefin-sync.md) (North American banks) is also available.
+:::
+
 ## GoCardless Setup
 
 ### Create SECRET and KEY for Actual


### PR DESCRIPTION
This adds a note on the Advanced/Bank Sync page linking to the SimpleFIN page:

<img width="642" alt="image" src="https://github.com/user-attachments/assets/82acba25-acdb-42f9-b503-1d8ee61b123c">
