### PR TITLE
Remove namespace from i18n example

### DIFF
--- a/docs/contributing/i18n.md
+++ b/docs/contributing/i18n.md
@@ -36,7 +36,7 @@ The `t()` function is the simplest form of translation, it accepts the text to b
 import { useTranslation } from 'react-i18next';
 
 function MyComponent() {
-  const { t } = useTranslation('myNamespace');
+  const { t } = useTranslation();
 
   return <p>{t('Hello World')}</p>;
 }

--- a/docs/contributing/i18n.md
+++ b/docs/contributing/i18n.md
@@ -61,7 +61,7 @@ i18next will take care of proper pluralization rules in the currently active lan
 When translating text with simple HTML tags or other React components, you will need to use the [`<Trans>` component](https://react.i18next.com/latest/trans-component).
 
 ```javascript
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 function MyComponent() {
   return (
@@ -69,5 +69,26 @@ function MyComponent() {
       Click <Link href={url}>here</Link> to become a millionaire.
     </Trans>
   );
+}
+```
+
+#### Interpolation with `<Trans>`
+
+Handling placeholder variables and pluralization within the `<Trans>` React component is handled slightly differently. For more details, please refer to [i18next-react's documentation](https://react.i18next.com/latest/trans-component#interpolation).
+
+
+```javascript
+import { Trans } from 'react-i18next';
+
+function MyComponent() {
+  const person = { name: "Pedro" };
+  // You can use an object literal within <Trans>!
+  return (
+    <Trans>
+      Your name is {{ name: person.name }}.
+    </Trans>
+  );
+  // This will result in the translation string:
+  // "Your name is {{name}}."
 }
 ```


### PR DESCRIPTION
Actual Budget does not use namespaces in the translations.
Also adds additional section about handling interpolation using the <Trans> component.