### PR TITLE
Add actualbudget home assistant integration link

### DIFF
--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -58,5 +58,5 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
    - *This is a bridging API between REST and the internal Actual APIs.*
 * **Actual Python API** - https://github.com/bvanelli/actualpy
    - *API to interact with the Actual server, written in Python.*
-* **Actual Buget Home Assistent Integration** - https://github.com/jlvcm/ha-actualbudget
-   - *Home Assistant Integration with an actual bugdet server*
+* **Actual Budget Home Assistant Integration** - https://github.com/jlvcm/ha-actualbudget
+   - *Home Assistant Integration with an Actual Bugdet server*

--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -59,4 +59,4 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
 * **Actual Python API** - https://github.com/bvanelli/actualpy
    - *API to interact with the Actual server, written in Python.*
 * **Actual Budget Home Assistant Integration** - https://github.com/jlvcm/ha-actualbudget
-   - *Home Assistant Integration with an Actual Bugdet server*
+   - *Home Assistant Integration with an Actual Budget server*

--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -58,3 +58,5 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
    - *This is a bridging API between REST and the internal Actual APIs.*
 * **Actual Python API** - https://github.com/bvanelli/actualpy
    - *API to interact with the Actual server, written in Python.*
+* **Actual Buget Home Assistent Integration** - https://github.com/jlvcm/ha-actualbudget
+   - *Home Assistant Integration with an actual bugdet server*


### PR DESCRIPTION
i've made a simple home assistant integration
https://github.com/jlvcm/ha-actualbudget

it allows me to use Home assistant to send the historic data to timescaleDB, access the balances through the assistant+chatgpt, and create alerts and graphs on Home assistant and grafana

i've done it in the last couple of days, so it's still on its first days, it's working but only has balances but it seems easy enough to add budgets and other data once i pick it up again

use it as you wish, and any contribution is welcome, if you need any help just let me know 🙏