### PR TITLE
Remove compose down from update instructions

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -42,7 +42,7 @@ You can optionally configure the container using environment variables — see t
 ### Update Docker Compose container
 
 ```bash
-$ docker-compose down && docker-compose pull && docker-compose up -d
+$ docker-compose pull && docker-compose up -d
 ```
 
 ## Launch container using docker command


### PR DESCRIPTION
docker compose down is not needed, and running it before pulling updated images causes longer service downtime than required.

Simply running `docker compose up -d` after `docker compose pull` will recreate all containers that changed (by either image version or other settings in the compose file).