### PR TITLE
Update rules page

### DIFF
--- a/docs/budgeting/rules/index.md
+++ b/docs/budgeting/rules/index.md
@@ -33,9 +33,10 @@ While ranking works for the most part, you might want to say "this rule _always_
 
 Conditions can use the following fields:
 
-- account
 - imported payee
 - payee
+- account
+- category
 - date
 - notes
 - amount
@@ -50,13 +51,15 @@ All strings are matched case-insensitive. An `imported payee` of "PuBlix" will m
 
 Actions can set the following fields:
 
+- category
 - payee
 - notes
+- cleared
+- account
 - date
 - amount
-- category
-- account
-- cleared
+
+Actions can also prepend or append text to the `notes` field.
 
 ## Automatic rules
 


### PR DESCRIPTION
Some minor updates to the rules page to keep it in sync with the current UI:

- Updates the list of actions and fields so the order matches the UI.
- Adds missing `category` field to the list
- Mentions you can also append/prepend to `notes`

See: https://deploy-preview-463.www.actualbudget.org/docs/budgeting/rules/