### PR TITLE
docs: Explain running balance is shown only with descending date

### DIFF
--- a/docs/getting-started/tips-tricks.md
+++ b/docs/getting-started/tips-tricks.md
@@ -60,7 +60,7 @@ This only controls the _maximum_ number of months. If the app is too small to re
 
 ## Show running balances
 
-A "running balance" is the balance of the account after every transaction over time. This is very useful for reconciling accounts with banks because you can see the balance at a specific date and use it to compare it with your bank.
+A "running balance" is the balance of the account after every transaction over time. This is very useful for reconciling accounts with banks because you can see the balance at a specific date and use it to compare it with your bank. Note that the "Show running balance" option and column is only available when the list of transactions is sorted by date in descending order.
 
 To enable this:
 


### PR DESCRIPTION
I was a little confused that I couldn't see a running balance in my accounts until I realized that it's only shown in a specific sort order. 

I think it would actually be useful to be able to see the running balance no matter the sorted order, but until then maybe we should clarify in the documentation.