### PR TITLE
Add dashboard and tracking budget links to latest release notes

### DIFF
--- a/blog/2024-12-05-release-24-12-0.md
+++ b/blog/2024-12-05-release-24-12-0.md
@@ -10,8 +10,8 @@ authors: matt-fidd
 
 The release has the following notable improvements:
 
-- Dashboards officially released as first-party feature
-- Tracking budget officially released as first-party feature
+- Dashboards (also called Reports) officially released as first-party feature (for details see: https://actualbudget.org/docs/tour/reports)
+- Tracking budget officially released as first-party feature (for details see https://actualbudget.org/docs/getting-started/tracking-budget)
 - New summary report card type
 - Batch sync for SimpleFin accounts
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,8 +3,8 @@
 ## 24.12.0
 
 The release has the following notable improvements:
-- Dashboards officially released as first-party feature
-- Tracking budget officially released as first-party feature
+- Dashboards (also called Reports) officially released as first-party feature (for details see: https://actualbudget.org/docs/tour/reports)
+- Tracking budget officially released as first-party feature (for details see https://actualbudget.org/docs/getting-started/tracking-budget)
 - New summary report card type
 - Batch sync for SimpleFin accounts
 


### PR DESCRIPTION
As a consumer of these release notes it would be nice to have links to the documentation for new major features. I think it's especially helpful for Dashboards because the official feature name in the docs is called Reports (it seems to colloquially called Dashboards)