### PR TITLE
Add auth proxies config to the docs

### DIFF
--- a/docs/advanced/http-header-auth.md
+++ b/docs/advanced/http-header-auth.md
@@ -18,7 +18,7 @@ Be careful! A misconfiguration on this next step could make your instance availa
 The SSO provider then needs to be configured to pass an extra HTTP header to Actual. The details on how to do this are unique to the SSO provider, but the header `x-actual-password` needs to be set to your actual password.
 
 
-If your setup needs it, it is possible to config trusted proxies. See [`trustedProxies` configuration](../config/index.md#trustedProxies) for details.
+If your setup needs it, it is possible to configure trusted proxies for authentication. See [`trustedAuthProxies` configuration](../config/index.md#trustedAuthProxies) for details.
 
 :::note
 This feature is not an HTTP basic auth, but a different form of using a password. For HTTP basic auth or user accounts see [this issue](https://github.com/actualbudget/actual/issues/524)

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -54,11 +54,21 @@ If you’re providing a custom frontend, make sure you provide an `index.html` i
 
 ## `loginMethod`
 
-Change the authentication method for Actual  (environment variable: `ACTUAL_LOGIN_METHOD`). The valid values are:
+Change the default authentication method for Actual  (environment variable: `ACTUAL_LOGIN_METHOD`). The valid values are:
 * `"password"` (default) - This is standard password authentication
 * `"header"` - Use the HTTP header `x-actual-password` to automatically login. This is for advanced use and if not done correctly could have security implications.
+* `"openid"` - OpenId auth (in preview)
 
+## `allowedLoginMethods`
+
+The list of login methods that are permitted for auth. This defaults to `['password','header','openid']` (environment variable: `ACTUAL_ALLOWED_LOGIN_METHODS`, comma separated string).
+
+If you wish to restrict the server from accepting certain login methods, you should update this setting.
 
 ## `trustedProxies`
 
-Config the clients that are allowed to authentic with HTTP headers. This defaults to known internal IP ranges: `[10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7, ::1/128]`  (environment variable: `ACTUAL_TRUSTED_PROXIES`, comma separated string).
+Updates the servers request forwarding trust to remove known proxy IPs from the client IP list. This helps identify the client IP for things like rate limiting. This defaults to known internal IP ranges: `[10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7, ::1/128]`  (environment variable: `ACTUAL_TRUSTED_PROXIES`, comma separated string).
+
+## `trustedAuthProxies`
+
+Configure the clients that are allowed to authentic with HTTP headers. This defaults to what is set in `trustedProxies`, but can be overridden independently. (environment variable: `ACTUAL_TRUSTED_AUTH_PROXIES`, comma separated string).


### PR DESCRIPTION
This is to go along with https://github.com/actualbudget/actual-server/pull/499 and should be merged until after that PR

This adds the new config options to the docs for the Auth proxy specific setting. 