### PR TITLE
Adding Portuguese prepaid meal card tracking from @rodriguestiago0.

### DIFF
--- a/.github/actions/spelling/allow/keywords.txt
+++ b/.github/actions/spelling/allow/keywords.txt
@@ -24,6 +24,7 @@ clsx
 codemirror
 Coinbase
 commandlet
+Coverflex
 Crd
 crdt
 creditcards

--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -6,7 +6,7 @@ They are for special use cases or for developing features that have not yet been
 
 These and other projects can be discussed in the #community-projects channel on the Actual Discord server.
 
-If you want your project listed here, notify people in the #documentation Discord channel. Before you can ask 
+If you want your project listed here, notify people in the #documentation Discord channel. Before you can ask
 for it to be added, your project must have a proper README file.
 
 ## Bank Importers
@@ -20,6 +20,18 @@ The following are implementations of bank syncing using the Actual API. For inst
 * **Monobank bank sync** - https://github.com/dnullproject/mono-to-actualbudget
 * **Norwegian Trumf Visa PDF invoice to Actual Budget friendly CSV converter** - https://github.com/RubenOlsen/TrumfVisa2ActualBudget
 * **Plaid bank sync** - https://github.com/youngcw/actualplaid
+
+
+
+## Other Importers
+
+Actual is used by some people to track money not necessarily found in bank accounts. This can be crypto currency
+tracking, loyalty card paybacks, prepaid cards, etc.
+
+* **Coinbase data puller** - https://github.com/SwadeDotExe/Coinbase-To-ActualBudget
+  - *This script pulls data from a USD and BTC wallet in Coinbase and keeps a wallet in Actual Budget synchronized with this balance.*
+* **Portuguese meal cards from My Edenred and Coverflex** - https://github.com/rodriguestiago0/actual-mealcards
+  - *This script will track Portuguese prepaid meal cards from My Edenred and Coverflex providers*
 
 
 ## Budget Migration
@@ -42,8 +54,6 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
    - *Collection of helper scripts to track home prices and car values, add loan interest transactions, track investment accounts, etc.*
 * **Actual Tasks** - https://github.com/rodriguestiago0/actual_task
    - *Two utilities to help fix payees and calculate mortgages.*
-* **Coinbase data puller** - https://github.com/SwadeDotExe/Coinbase-To-ActualBudget
-   - *This script pulls data from a USD and BTC wallet in Coinbase and keeps a wallet in Actual Budget synchronized with this balance.*
 * **Easy category archive function** - https://github.com/rvisharma/actual-archive-category
    - *This tool moves transactions over to an _archive_ category, and then deletes the category.*
 * **Actual Budget Backup** - https://github.com/rodriguestiago0/actualbudget-backup


### PR DESCRIPTION
Also grouped this with with the Coinbase sync under a new heading called Other Importers, as they are not necessarily pure banking-related importers.