### PR TITLE
Update instructions for enabling Tracking Budget

### DIFF
--- a/docs/getting-started/tracking-budget.md
+++ b/docs/getting-started/tracking-budget.md
@@ -11,8 +11,7 @@ We, the Actual team, suggest that you try to use the **Envelope Budget** if you 
 
 ## Enabling the Tracking Budget
 
-The **Tracking Budget** feature can be switched on from the Experimental features section within the Settings page by enabling "Budget mode toggle".
-Then scroll up in the settings menu and click "Switch to tracking budgeting".
+The **Tracking Budget** feature can be enabled from the Settings page by clicking on "Switch to tracking budgeting".
 
 ![](/img/tracking-budget-7.png)
 


### PR DESCRIPTION
This PR updates the instructions for enabling Tracking Budget. The feature is no longer experimental, but the documentation still treats it as such.