### PR TITLE
Update docker compose command

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -34,7 +34,7 @@ You can use the [`docker-compose.yml` file included in the `actual-server` repos
 To create and run the container:
 
 ```bash
-$ docker-compose up --detach
+$ docker compose up --detach
 ```
 
 You can optionally configure the container using environment variables — see the [configuration section](../config/index.md) for more details.
@@ -42,7 +42,7 @@ You can optionally configure the container using environment variables — see t
 ### Update Docker Compose container
 
 ```bash
-$ docker-compose pull && docker-compose up -d
+$ docker compose pull && docker compose up -d
 ```
 
 ## Launch container using docker command


### PR DESCRIPTION
Update to newer docker compose command.

From the docs: From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
See the docs: https://docs.docker.com/compose/releases/migrate