### PR TITLE
🔖 (25.2.1) fix desktop apps and reports page

### DIFF
--- a/blog/2025-02-06-release-25-2-1.md
+++ b/blog/2025-02-06-release-25-2-1.md
@@ -1,0 +1,23 @@
+---
+title: Release 25.2.1
+description: New release of Actual.
+date: 2025-02-06T18:00
+slug: release-25.2.1
+tags: [announcement, release]
+hide_table_of_contents: false
+authors: matt-fidd
+---
+
+The primary intent of this release is to patch regressions that prevented the reports page from loading when the selected language was not English, and the desktop apps from working.
+
+<!--truncate-->
+
+**Docker tag: 25.2.1**
+
+## Actual
+
+#### Bugfix
+
+- [#4303](https://github.com/actualbudget/actual/pull/4303) Fix crashes on reports page with translations enabled — thanks @jfdoming
+- [#4312](https://github.com/actualbudget/actual/pull/4312) Fix broken Weblate URL in settings if the language option has never been set — thanks @matt-fidd
+- [#4317](https://github.com/actualbudget/actual/pull/4317) Fix Electron language support — thanks @MikesGlitch

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 25.2.1
+
+The primary intent of this release is to patch regressions that prevented the reports page from loading when the selected language was not English, and the desktop apps from working.
+
+### Actual
+
+#### Bugfix
+
+- [#4303](https://github.com/actualbudget/actual/pull/4303) Fix crashes on reports page with translations enabled — thanks @jfdoming
+- [#4312](https://github.com/actualbudget/actual/pull/4312) Fix broken Weblate URL in settings if the language option has never been set — thanks @matt-fidd
+- [#4317](https://github.com/actualbudget/actual/pull/4317) Fix Electron language support — thanks @MikesGlitch
+
 ## 25.2.0
 
 The release has the following notable improvements:


### PR DESCRIPTION
What commits will be included in the release?

https://github.com/actualbudget/actual/compare/v25.2.1?expand=1

---

- web: https://github.com/actualbudget/actual/pull/4319
- server: https://github.com/actualbudget/actual-server/pull/565
- docs: https://github.com/actualbudget/docs/pull/628