### PR TITLE
Update github container reference to new repo

### DIFF
--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -14,7 +14,7 @@ The reasons for this change are as follows:
 
 - **Q.** _I use Docker Hub/Github's container registry, how do I stay up to date?_
 
-  **A.** We will continue to push images to [Docker Hub](https://hub.docker.com/r/actualbudget/actual-server) and [Github's container registry](https://ghcr.io/actualbudget/actual-server) as usual.
+  **A.** We will continue to push images to [Docker Hub](https://hub.docker.com/r/actualbudget/actual-server) and [Github's container registry](https://ghcr.io/actualbudget/actual) as usual.
 
 
 - **Q.** _I build the docker image locally, can I still do that?_

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 ## Hosting Actual on a home server with Docker
 
-Actual is also available as a Docker image ready to be run in your own custom environment. We publish the image both to [Docker Hub](https://hub.docker.com/r/actualbudget/actual-server) (as `actualbudget/actual-server`) and [GitHub’s container registry](https://ghcr.io/actualbudget/actual-server) (as `ghcr.io/actualbudget/actual-server`). Actual should function the same when pulled from either registry, so you can choose whichever one you prefer.
+Actual is also available as a Docker image ready to be run in your own custom environment. We publish the image both to [Docker Hub](https://hub.docker.com/r/actualbudget/actual-server) (as `actualbudget/actual-server`) and [GitHub’s container registry](https://ghcr.io/actualbudget/actual) (as `ghcr.io/actualbudget/actual`). Actual should function the same when pulled from either registry, so you can choose whichever one you prefer.
 
 ## Docker Tags
 


### PR DESCRIPTION
Updating to point to the new github container located here: https://ghcr.io/actualbudget/actual

This is to accommodate this change: https://github.com/actualbudget/actual/pull/4483