### PR TITLE
Update docs with new instructions for workspace reference in server

### DIFF
--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -35,14 +35,18 @@ The reasons for this change are as follows:
   ```
   3. Install the required dependencies for the server:
   ```
-  yarn workspaces focus @actual-app/sync-server --production
+  yarn install
   ```
-  4. If you have a [config.json](https://actualbudget.com/docs/config/) file you will need to copy it into the following directory:
+  4. Build the server:
+  ```
+  yarn build:server
+  ```
+  5. If you have a [config.json](https://actualbudget.com/docs/config/) file you will need to copy it into the following directory:
   ```
   packages/sync-server
   ```
-  5. Copy over the data from your `actual-server` directory (`user-files`, `server-files`, and `.migrate`) into the `packages/sync-server` directory.
-  6. Run the server with:
+  6. Copy over the data from your `actual-server` directory (`user-files`, `server-files`, and `.migrate`) into the `packages/sync-server` directory.
+  7. Run the server with:
   ```
   yarn start:server
   ```

--- a/docs/contributing/project-details/index.md
+++ b/docs/contributing/project-details/index.md
@@ -38,26 +38,15 @@ The shared underlying functionality component used by both the web/desktop front
 
 ## Sync Server
 
-The Sync Server, also known as Actual Server, holds all of the code for the synchronization element of the Actual Budget application. Actual server has a dependency of Actual so when you pull Actual Server and deploy it to your hosting method of choice, be that Fly, Local etc. and run `yarn workspaces focus @actual-app/sync-server --production` Actual will be downloaded as a dependency from NPM and installed into the Actual Server deployment.
+The Sync Server, also known as Actual Server, holds all of the code for the synchronization element of the Actual Budget application. Actual server has a dependency of Actual so when you deploy Actual Server to your hosting method of choice, be that Fly, Local etc. and run `yarn build:server` and `yarn install`, the Actual client will be installed as a dependency into the Actual Server deployment.
 
 You can see this in the [package.json](https://github.com/actualbudget/actual/blob/master/packages/sync-server/package.json) file;
 
 ```json
 "dependencies": {
-    "@actual-app/api": "4.1.0",
-    "@actual-app/web": "4.1.0",
-    "bcrypt": "^5.0.1",
-    "better-sqlite3": "^7.5.0",
-    "body-parser": "^1.18.3",
-    "cors": "^2.8.5",
-    "express": "4.17",
-    "express-actuator": "^1.8.1",
-    "express-response-size": "^0.0.3",
-    "node-fetch": "^2.2.0",
-    "uuid": "^3.3.2"
+    "@actual-app/web": "workspace:*",
+    // rest of dependencies...
   },
 ```
 
-So, you might see some changes being made in the Actual repository but those changes are not reflected in your deployment despite you having the latest version pulled, why? Because Actual hasn't been updated in [NPM](https://www.npmjs.com/package/@actual-app/web).
-
-Actual is only updated in NPM when a release is created.
+The workspace reference ensures that changes to @actual-app/web are reflected in your server deployment. If you see any discrepencies it means you need to run `yarn build:server` to compile the latest.

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -1,13 +1,10 @@
 # How to Cut a Release
 
-In the open-source version of Actual, all updates go through NPM. There are two libraries:
+In the open-source version of Actual, all updates go through NPM. There is one npm package:
 
 `@actual-app/api`: The API for the underlying functionality. This includes the entire backend of Actual, meant to be used with Node.
 
-`@actual-app/web`: A web build that will serve the app with a web frontend. This includes both the frontend and backend of Actual. It includes the backend as well because it's built to be used as a Web Worker.
-
-Both the API and web libraries are versioned together. This may change in the future, but because the web library also brings along its own backend it's easier to maintain a single version for now. That makes it clear
-which version the backend is regardless of library.
+Both the API and the main Actual release are versioned together. That makes it clear which version of the API should be used with the version of Actual.
 
 ### Versioning Strategy
 
@@ -23,7 +20,7 @@ For example:
 - `v23.4.0` - first release launched on 9th of April, 2023;
 
 ## Setting up the PRs
-Pull requests will need to be opened in all two repositories - [docs](https://github.com/actualbudget/docs), [actual](https://github.com/actualbudget/actual).
+Pull requests will need to be opened in two repositories - [docs](https://github.com/actualbudget/docs), [actual](https://github.com/actualbudget/actual).
 
 Make sure to name the branch `release/X.Y.Z` where `X.Y.Z` is the version number. This will trigger the release notes tooling, which will comment on your PR with the generated release notes. You can then copy-paste the release notes into the `Release-Notes.md` file in the `docs ` repository.
 
@@ -42,39 +39,13 @@ This automation will also delete all the outdated release note files from the `u
 After the release notes workflows in the actual PR has been run, copy the collated notes into a new blog post using a previous release as a template. The release notes will also need adding to the `docs/releases.md` file.
 
 ## Building and Publishing to NPM
-Once the web PR has been approved, the new version of the API and web packages need to be published to NPM. If you haven't done this before, another maintainer will need to give you access.
+Once the Actual repository PR has been approved, the new version of the API package needs to be published to NPM. If you haven't done this before, another maintainer will need to give you access.
 
 ###  @actual-app/api
 
 ```bash
 cd packages/api
 yarn build
-yarn npm publish --access public
-```
-
-### @actual-app/web
-
-First, pull the latest translations:
-```bash
-cd packages/desktop-client
-! [ -d locale ] && git clone https://github.com/actualbudget/translations.git locale
-cd locale
-git checkout -- .
-git pull
-```
-
-Next, in the root of actual (not just desktop-client), run:
-
-```bash
-yarn build:browser
-```
-
-This will compile both the backend and the frontend into a single directory in `packages/desktop-client/build`. This directory contains all of the files that need to be published.
-
-Now you can publish the package by running:
-
-```bash
-cd packages/desktop-client
 yarn npm publish --access public
 ```
 

--- a/docs/contributing/windows.md
+++ b/docs/contributing/windows.md
@@ -4,7 +4,7 @@ Many of the build scripts are bash scripts and not natively invocable in Windows
 
 1. Install [Git & Git Bash for Windows](https://git-scm.com/downloads).
 2. Ensure you have activated [Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development).
-3. Install Node v16.x (latest version 17.x does not work due to issue with crypto package).
+3. Install Node v18.x or greater.
 4. Clone this repo.
 5. Using Git Bash (run as administrator), change to the root of this repo.
 6. From inside the bash shell, run `yarn install`.

--- a/docs/install/local.md
+++ b/docs/install/local.md
@@ -29,12 +29,16 @@ Actual server is used for syncing changes across devices. It comes with the late
     ```
 3. Install all the required dependencies using yarn.
     ```bash
-    yarn workspaces focus @actual-app/sync-server --production
+    yarn install
+    ```
+4. Build the server with
+    ```bash
+    yarn build:server
     ```
 
 ## Running Actual
 
-After the Actual is installed, start the Actual server by running the following command:
+After the Actual is installed and built, start the Actual server by running the following command:
 ```bash
 yarn start:server
 ```
@@ -90,8 +94,9 @@ When accessing Actual for the first time, you may be prompted to provide a URL f
 ## Updating Actual
 
 1. Stop the server if it’s running. You can use the keyboard shortcut <kbd>CTRL-C</kbd> (even on macOS) to stop the server or close the terminal window it’s running from.
-2. Run `git pull` from the directory you cloned the project into. This will download the latest server code.
-3. Run `yarn workspaces focus @actual-app/sync-server --production` from that directory. This will download the latest web client code, along with any updated dependencies for the server.
+2. Run `git pull` from the directory you cloned the project into. This will download the latest code.
+3. Run `yarn install` from that directory. This will download any updated dependencies.
+4. Run `yarn build:server` to build the server from the latest code.
 4. Restart the server by running `yarn start:server`.
 
 Actual is constantly evolving to include new features and improve the user's experience. It is always recommended that your local installation be updated with our [latest releases](https://actualbudget.org/docs/releases).


### PR DESCRIPTION
Should be merged with: https://github.com/actualbudget/actual/pull/4569

**Changed pages:** 
- https://deploy-preview-661.www.actualbudget.org/docs/install/local
- https://deploy-preview-661.www.actualbudget.org/docs/contributing/project-details/
- https://deploy-preview-661.www.actualbudget.org/docs/contributing/releasing/
- https://deploy-preview-661.www.actualbudget.org/docs/contributing/windows/
- https://deploy-preview-661.www.actualbudget.org/docs/actual-server-repo-move/
