### PR TITLE
Adding git bash as a prereq for Windows & renaming local install to Build from source

### DIFF
--- a/docs-sidebar.js
+++ b/docs-sidebar.js
@@ -65,7 +65,11 @@ const sidebars = {
               type: 'category',
               label: 'On Your Own Machine',
               collapsible: false,
-              items: ['install/build-from-source', 'install/docker'],
+              items: [
+                'install/docker',
+                { type: 'link', label: 'Desktop app', href: 'downloads' },
+                'install/build-from-source',
+              ],
             },
 
             {

--- a/docs-sidebar.js
+++ b/docs-sidebar.js
@@ -67,7 +67,7 @@ const sidebars = {
               collapsible: false,
               items: [
                 'install/docker',
-                { type: 'link', label: 'Desktop app', href: 'downloads' },
+                { type: 'link', label: 'Desktop app', href: '/download' },
                 'install/build-from-source',
               ],
             },

--- a/docs-sidebar.js
+++ b/docs-sidebar.js
@@ -65,7 +65,7 @@ const sidebars = {
               type: 'category',
               label: 'On Your Own Machine',
               collapsible: false,
-              items: ['install/local', 'install/docker'],
+              items: ['install/build-from-source', 'install/docker'],
             },
 
             {

--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -22,7 +22,7 @@ The reasons for this change are as follows:
   **A.** All of the docker files are still available. To build the sync server locally you can use the ``` sync-server.Dockerfile``` located in the root of the repository.  The ``` docker-compose.yml ``` is located in the ```/packages/sync-server``` directory.
 
 
-- **Q.** _I use the [Local Installation](https://actualbudget.org/docs/install/local). How do I keep up to date?_
+- **Q.** _I [Build from source](https://actualbudget.org/docs/install/build-from-source). How do I keep up to date?_
 
   **A.** Follow these instructions:
   1. Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:

--- a/docs/config/https.md
+++ b/docs/config/https.md
@@ -21,7 +21,7 @@ Use a service like [Tailscale](https://tailscale.com/kb/1153/enabling-https/) or
 Once you have the certificate, you’ll need to configure Actual to use it. There are two methods to do this:
 
 ### Configuring with `config.json`:
-Create a `config.json` file in the same folder where you run the Actual Sync Server. If you are running a [local installation](https://actualbudget.com/docs/install/local) this will be in ```packages/sync-server/```. Put the paths to the `.key` and `.crt` files in the config file. Note: if you’re using Docker or a similar container environment, make sure the paths are accessible to the container.
+Create a `config.json` file in the same folder where you run the Actual Sync Server. If you are [building from source](https://actualbudget.com/docs/install/build-from-source) this will be in ```packages/sync-server/```. Put the paths to the `.key` and `.crt` files in the config file. Note: if you’re using Docker or a similar container environment, make sure the paths are accessible to the container.
 
 If using a Docker container, this folder is `/data` within the container. If you mounted a volume for the container, the folder on the host where `/data` is mounted is where you can place the `config.json` file.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2,7 +2,7 @@
 title: Configuring the Server
 ---
 
-When it starts up, Actual looks for an optional `config.json` file in the same directory as the sync-server's `package.json`. If you are running a [local installation](https://actualbudget.com/docs/install/local) this will be in ```packages/sync-server/```. If present, any keys you define there will override the default values. All values can also be specified as environment variables, which will override the values in the `config.json` file.
+When it starts up, Actual looks for an optional `config.json` file in the same directory as the sync-server's `package.json`. If you are running a [building from source](https://actualbudget.com/docs/install/build-from-source) this will be in ```packages/sync-server/```. If present, any keys you define there will override the default values. All values can also be specified as environment variables, which will override the values in the `config.json` file.
 
 :::info
 
@@ -30,21 +30,21 @@ You can’t specify this option in `config.json` since it needs to be used to fi
 
 ## `ACTUAL_UPLOAD_FILE_SYNC_SIZE_LIMIT_MB`
 
-Defines the maximum allowed size for sync files (in MB).  
+Defines the maximum allowed size for sync files (in MB).
 
-The default value is `20`.  
+The default value is `20`.
 
 ## `ACTUAL_UPLOAD_SYNC_ENCRYPTED_FILE_SYNC_SIZE_LIMIT_MB`
 
-Defines the maximum allowed size for encrypted sync files (in MB).  
+Defines the maximum allowed size for encrypted sync files (in MB).
 
-The default value is `50`.  
+The default value is `50`.
 
 ## `ACTUAL_UPLOAD_FILE_SIZE_LIMIT_MB`
 
-Defines the general maximum file size limit (in MB) for uploads.  
+Defines the general maximum file size limit (in MB) for uploads.
 
-The default value is `20`.  
+The default value is `20`.
 
 ## `https`
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -2,7 +2,7 @@
 title: Configuring the Server
 ---
 
-When it starts up, Actual looks for an optional `config.json` file in the same directory as the sync-server's `package.json`. If you are running a [building from source](https://actualbudget.com/docs/install/build-from-source) this will be in ```packages/sync-server/```. If present, any keys you define there will override the default values. All values can also be specified as environment variables, which will override the values in the `config.json` file.
+When it starts up, Actual looks for an optional `config.json` file in the same directory as the sync-server's `package.json`. If you are [building from source](https://actualbudget.com/docs/install/build-from-source) this will be in ```packages/sync-server/```. If present, any keys you define there will override the default values. All values can also be specified as environment variables, which will override the values in the `config.json` file.
 
 :::info
 

--- a/docs/getting-started/roadmap-for-new-users.md
+++ b/docs/getting-started/roadmap-for-new-users.md
@@ -35,9 +35,9 @@ However, if you are adventurous or somewhat technical, please go directly to the
 
 Then you are in luck. We have guides for the following systems:
 
-* [Local installation](/docs/install/local)
 * [Docker installation](/docs/install/docker)
 * [Fly.io installation](/docs/install/fly)
+* [Build from source](/docs/install/build-from-source)
 
 There is also an external guide explaining how to install Actual on:
 

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -1,6 +1,6 @@
 # Build from source
 
-:::warning
+:::info
 
 Installing Actual by building it from source is a highly technical process. We recommend this approach primarily for power users and contributors.
 

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -1,6 +1,15 @@
-# Local Installation
+# Build from source
 
-The easiest way to get Actual running locally is to use [actual-server](https://github.com/actualbudget/actual/tree/master/packages/sync-server).
+:::warning
+
+Building from source is a highly technical method of installing Actual. We typically recommend it for power users/contributors of Actual.
+
+For non-technical users we recommend using either:
+- [Pikapods](/docs/install/pikapods)
+- [Desktop Client](/download)
+- [Docker](/docs/install/docker)
+
+:::
 
 Actual server is used for syncing changes across devices. It comes with the latest version of the [Actual web client](https://github.com/actualbudget/actual).
 

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -4,7 +4,7 @@
 
 Installing Actual by building it from source is an advanced, highly technical process. We recommend this approach primarily for power users and contributors.
 
-For non-technical users, we suggest opting for one of these simpler alternatives:
+For non-technical users, we suggest opting for one of the simpler alternatives:
 - [Pikapods](/docs/install/pikapods)
 - [Desktop Client](/download)
 - [Docker](/docs/install/docker)

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -2,9 +2,9 @@
 
 :::warning
 
-Building from source is a highly technical method of installing Actual. We typically recommend it for power users/contributors of Actual.
+Installing Actual by building it from source is an advanced, highly technical process. We recommend this approach primarily for power users and contributors.
 
-For non-technical users we recommend using either:
+For non-technical users, we suggest opting for one of these simpler alternatives:
 - [Pikapods](/docs/install/pikapods)
 - [Desktop Client](/download)
 - [Docker](/docs/install/docker)

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -2,7 +2,7 @@
 
 :::warning
 
-Installing Actual by building it from source is an advanced, highly technical process. We recommend this approach primarily for power users and contributors.
+Installing Actual by building it from source is a highly technical process. We recommend this approach primarily for power users and contributors.
 
 For non-technical users, we suggest opting for one of the simpler alternatives:
 - [Pikapods](/docs/install/pikapods)

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -47,8 +47,8 @@ While running a server can be a complicated endeavor, we’ve tried to make it f
 - If you’re not comfortable with the command line and are willing to pay a small amount of money to have your version of Actual hosted on the cloud for you, we recommend [PikaPods](pikapods.md).[^2]
 - If you’re willing to run a few commands in the terminal:
   - [Fly.io](fly.md) also offers cloud hosting for a similar amount of money.
-  - You could [directly install Actual locally](local.md) on macOS, Windows, or Linux if you don’t want to use a tool like Docker. (This method is the best option if you want to contribute to Actual's development!)
   - If you want to use Docker, we have instructions for [using our provided Docker containers](docker.md).
+  - You could [build Actual from source](build-from-source.md) on macOS, Windows, or Linux if you don’t want to use a tool like Docker. (This method is the best option if you want to contribute to Actual's development!)
 
 Once you’ve set up your server, you can [configure it](../config/index.md) to change a few of the ways it works.
 

--- a/docs/install/local.md
+++ b/docs/install/local.md
@@ -9,7 +9,7 @@ Actual server is used for syncing changes across devices. It comes with the late
 - The Actual server requires Node.js v18 or greater. You can download and install the latest version of Node.js from [Node.js website](https://nodejs.org/en/download) (we recommend downloading the “LTS” version).
   - If you're on Windows, during installation of Node.js, be sure to select _Automatically install the necessary tools_ from the _Tools for Native Modules_ page. This is required to build better-sqlite3. If you missed this when you installed Node.js, double-click ```C:\Program Files\nodejs\install_tools.bat``` from the File Explorer or run it in a terminal.
 - Consider using a tool like [nvm](https://github.com/nvm-sh/nvm) or [asdf](https://asdf-vm.com) to install and manage multiple versions of Node.js.
-- You’ll also need to have Git installed. The Git website has [instructions for downloading and working with Git for all supported operating systems](https://git-scm.com/download).
+- You’ll also need to have Git installed. For Windows users, you'll also need Git Bash. The Git website has [instructions for downloading and working with Git for all supported operating systems](https://git-scm.com/download).
 - Actual uses yarn packages. You can install [yarn](https://yarnpkg.com/getting-started/install) using the following command:
 
   ```bash

--- a/src/pages/download.md
+++ b/src/pages/download.md
@@ -21,6 +21,6 @@ The simplest way to use Actual is to download the desktop application.  This wil
 ## Server Download
 Actual has two parts, the client and a sync server.  The primary task of the sync server is to sync your budget between devices, and to enable bank syncing.  We have a full write up of [if you need a server or not](/docs/install/). We also have install guides on how to set up the server in the following ways
 * [Docker Install](/docs/install/docker)
-* [Local Installation](/docs/install/local)
+* [Local Installation](/docs/install/build-from-source)
 * [PikaPods](/docs/install/pikapods)
 * [Fly.io](/docs/install/fly)

--- a/src/pages/download.md
+++ b/src/pages/download.md
@@ -20,7 +20,7 @@ The simplest way to use Actual is to download the desktop application.  This wil
 
 ## Server Download
 Actual has two parts, the client and a sync server.  The primary task of the sync server is to sync your budget between devices, and to enable bank syncing.  We have a full write up of [if you need a server or not](/docs/install/). We also have install guides on how to set up the server in the following ways
-* [Docker Install](/docs/install/docker)
-* [Local Installation](/docs/install/build-from-source)
 * [PikaPods](/docs/install/pikapods)
 * [Fly.io](/docs/install/fly)
+* [Docker Install](/docs/install/docker)
+* [Build from source](/docs/install/build-from-source)


### PR DESCRIPTION
- Added desktop app to installation options "on your own machine" 
- For building from source
  - Windows Users will need Git Bash so that they can build the web client using the bash scripts.
  - Added a warning on the build from source page
  - Reordered the _Build from source_ link to the bottom to encourage the simpler options insted

![image](https://github.com/user-attachments/assets/d1dd032f-0482-444d-9e2d-2d0fe5cab980)

![image](https://github.com/user-attachments/assets/694f9303-d35e-44ba-b00e-2c6c3187bb88)


