### PR TITLE
[WIP] free tier clarification in gocardless.md

### DIFF
--- a/docs/advanced/bank-sync/gocardless.md
+++ b/docs/advanced/bank-sync/gocardless.md
@@ -108,11 +108,14 @@ If you are setting up Actual for the first time, it is much easier not to try to
 
 
 **How many times can I sync with  GoCardless?**
-In the free tier, you can sync 50 times per month. If you sync to two different banks (with three accounts in each bank), that is counted as two connections.
+
+In the free tier, you can connect up to 50 banks per month. If one of your banks include more than one account inside (like credit and debit cards), it will still be counted as one connection.
+Every day you can sync each bank up to 4 times and there is no monthly limit though, just the daily one.
 For more information, see the [Bank Account Data API Usage](https://bankaccountdata.zendesk.com/hc/en-gb/articles/11528933493916-Bank-Account-Data-API-Usage-how-is-your-usage-number-calculated)
 topic in the GoCardless FAQ.
 
 **What if my bank only supports 90 days of historical data?**
+
 If your bank limits the amount of historical data you can fetch, you need to add your bank to the list of such banks in the Actual server code.
 
 To achieve this:


### PR DESCRIPTION
Hi!

I asked GoCardless support to have more informations about the free tier. They told me that the 50 connections (techincally **requisitions**) per month are actually the "initial" connections to the bank. 
Then you have a limit of 4 sync for each bank every day. There's no a monthly limit for syncing.
I have 3 banks linked in actual budget and this was their answer:

>Yes, can confirm that it would be 3 out of your 50 available requisitions monthly. 
As for the amount of times you can sync transactions daily - there's a limit by banks where it's 4 calls for transactions per 24 hours per account_id. Same goes for account details and balances - 4 requests for each in a 24 hour period for each account_id. There is no monthly limit though, just the daily one. This is explained in more detail [here](https://bankaccountdata.zendesk.com/hc/en-gb/articles/11529584398236-Bank-API-Rate-Limits-and-Rate-Limit-Headers).