### PR TITLE
Updating repo move instructions to include bash requirement

### DIFF
--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -25,7 +25,10 @@ The reasons for this change are as follows:
 - **Q.** _I [Build from source](https://actualbudget.org/docs/install/build-from-source). How do I keep up to date?_
 
   **A.** Follow these instructions:
-  1. Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
+  
+  For Windows users, you'll need [Git Bash](https://git-scm.com/download).
+
+  1. Open Git Bash and Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
   ```
   git clone https://github.com/actualbudget/actual.git
   ```

--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -28,7 +28,7 @@ The reasons for this change are as follows:
   
   For Windows users, you'll need [Git Bash](https://git-scm.com/download).
 
-  1. Open Bash and Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
+  1. Open Bash, then Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
   ```
   git clone https://github.com/actualbudget/actual.git
   ```

--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -28,7 +28,7 @@ The reasons for this change are as follows:
   
   For Windows users, you'll need [Git Bash](https://git-scm.com/download).
 
-  1. Open Git Bash and Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
+  1. Open Bash and Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
   ```
   git clone https://github.com/actualbudget/actual.git
   ```

--- a/docs/actual-server-repo-move.md
+++ b/docs/actual-server-repo-move.md
@@ -26,7 +26,7 @@ The reasons for this change are as follows:
 
   **A.** Follow these instructions:
   
-  For Windows users, you'll need [Git Bash](https://git-scm.com/download).
+  If you are on Windows, you'll need to install [Git Bash](https://git-scm.com/download).
 
   1. Open Bash, then Clone the [Actual repository](https://github.com/actualbudget/actual). You can use the following command:
   ```


### PR DESCRIPTION
It should help people moving to the new repo on Windows:

Based on this:
https://discord.com/channels/937901803608096828/1355224207541276826/1355229374986719242