### PR TITLE
Ngrok reverse proxy docs

### DIFF
--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -160,3 +160,43 @@ Apache HTTP server can serve as a reverse proxy using [VirtualHosts](https://htt
 </VirtualHost>
 ```
 
+## Ngrok
+
+[Ngrok](https://ngrok.com/) offer a reverse proxy and a static domain fror [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
+
+Creating an ngrok free domain is very simple, just navigate to the Domains section of the site. For more information, check out the [custom domain docs](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/).
+
+Once that's all done, you can expose Actual to the internet with your custom domain and free SSL with a simple command:
+
+```
+ngrok http --url=your-custom-domain.ngrok-free.app 5006
+```
+
+If running Actual your your PC, you may find it useful to run this command when your computer starts up. There are many ways to do this, the below is not a complete list:
+
+- On Windows you can use the [Task Scheduler](https://www.technipages.com/scheduled-task-windows/)
+  - Create a *Basic Task*, give it a name then set the trigger to *At system startup*
+  - Under *Action*, select the program as ngrok.exe, and add arguments ```http --url=your-custom-domain.ngrok-free.app 5006```.
+  - Once complete, you can choose to run this silently in the background by navigating to *properties* and selecting *Run whether user is logged on or not* and ticking the *Hidden* box.
+
+- On Linux you can use [systemd](https://systemd.io/)
+  - Create a service file:
+
+    ```sudo nano /etc/systemd/system/  expose-actual-server.service```
+    - Add the following content:
+    ```
+    [Unit]
+    Description=Run my Bash script at startup
+    After=network.target
+
+    [Service]
+    ExecStart=ngrok http --url=your-custom-domain.    ngrok-free.app 5006
+    Restart=always
+    User=myuser
+
+    [Install]
+    WantedBy=multi-user.target
+    ```
+  - Enable the service:
+
+    ```sudo systemctl enable expose-actual-server.service```

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -177,7 +177,7 @@ If running Actual on your PC, you may find it helpful to run this command when y
 - On Windows, you can use the [Task Scheduler](https://www.technipages.com/scheduled-task-windows/)
   - Create a *Basic Task*, give it a name then set the trigger to *At system startup*
   - Under *Action*, select the program as ngrok.exe, and add arguments ```http --url=your-custom-domain.ngrok-free.app 5006```.
-  - Once complete, you can choose to run this silently in the background by navigating to *properties* and selecting *Run whether user is logged on or not* and ticking the *Hidden* box.
+  - Once complete, you can choose to run this silently in the background by navigating to *properties*, selecting *Run whether user is logged on or not*, and ticking the *Hidden* box.
 
 - On Linux you can use [systemd](https://systemd.io/)
   - Navigate to the directory: `/etc/systemd/system/` and create a service file `expose-actual-server.service`

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -180,10 +180,8 @@ If running Actual on your PC, you may find it useful to run this command when yo
   - Once complete, you can choose to run this silently in the background by navigating to *properties* and selecting *Run whether user is logged on or not* and ticking the *Hidden* box.
 
 - On Linux you can use [systemd](https://systemd.io/)
-  - Create a service file:
-
-    ```sudo nano /etc/systemd/system/  expose-actual-server.service```
-    - Add the following content and replace the relevant info:
+  - Navigate to the directory: `/etc/systemd/system/` and create a service file `expose-actual-server.service`
+  - Add the following content (and change to suit your needs):
     ```
     [Unit]
     Description=Run my Bash script at startup
@@ -197,6 +195,4 @@ If running Actual on your PC, you may find it useful to run this command when yo
     [Install]
     WantedBy=multi-user.target
     ```
-  - Enable the service:
-
-    ```sudo systemctl enable expose-actual-server.service```
+  - Enable the service with ```sudo systemctl enable expose-actual-server.service```

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -164,7 +164,7 @@ Apache HTTP server can serve as a reverse proxy using [VirtualHosts](https://htt
 
 [Ngrok](https://ngrok.com/) offers a reverse proxy and a static domain for [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
 
-Creating an ngrok free domain is very simple, just navigate to the Domains section of the site. For more information, check out the [custom domain docs](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/).
+Creating a free Ngrok domain is very simple: just navigate to the Domains section of the site. For more information, check out the [custom domain docs](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/).
 
 Once that's all done, you can expose Actual to the internet with your custom domain and free SSL with a simple command:
 

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -174,7 +174,7 @@ ngrok http --url=your-custom-domain.ngrok-free.app 5006
 
 If running Actual on your PC, you may find it helpful to run this command when your computer starts up. There are many ways to do this. The below is not a complete list:
 
-- On Windows you can use the [Task Scheduler](https://www.technipages.com/scheduled-task-windows/)
+- On Windows, you can use the [Task Scheduler](https://www.technipages.com/scheduled-task-windows/)
   - Create a *Basic Task*, give it a name then set the trigger to *At system startup*
   - Under *Action*, select the program as ngrok.exe, and add arguments ```http --url=your-custom-domain.ngrok-free.app 5006```.
   - Once complete, you can choose to run this silently in the background by navigating to *properties* and selecting *Run whether user is logged on or not* and ticking the *Hidden* box.

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -172,7 +172,7 @@ Once that's all done, you can expose Actual to the internet with your custom dom
 ngrok http --url=your-custom-domain.ngrok-free.app 5006
 ```
 
-If running Actual on your PC, you may find it useful to run this command when your computer starts up. There are many ways to do this, the below is not a complete list:
+If running Actual on your PC, you may find it helpful to run this command when your computer starts up. There are many ways to do this. The below is not a complete list:
 
 - On Windows you can use the [Task Scheduler](https://www.technipages.com/scheduled-task-windows/)
   - Create a *Basic Task*, give it a name then set the trigger to *At system startup*

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -162,7 +162,7 @@ Apache HTTP server can serve as a reverse proxy using [VirtualHosts](https://htt
 
 ## Ngrok
 
-[Ngrok](https://ngrok.com/) offer a reverse proxy and a static domain fror [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
+[Ngrok](https://ngrok.com/) offer a reverse proxy and a static domain for [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
 
 Creating an ngrok free domain is very simple, just navigate to the Domains section of the site. For more information, check out the [custom domain docs](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/).
 
@@ -172,7 +172,7 @@ Once that's all done, you can expose Actual to the internet with your custom dom
 ngrok http --url=your-custom-domain.ngrok-free.app 5006
 ```
 
-If running Actual your your PC, you may find it useful to run this command when your computer starts up. There are many ways to do this, the below is not a complete list:
+If running Actual on your PC, you may find it useful to run this command when your computer starts up. There are many ways to do this, the below is not a complete list:
 
 - On Windows you can use the [Task Scheduler](https://www.technipages.com/scheduled-task-windows/)
   - Create a *Basic Task*, give it a name then set the trigger to *At system startup*
@@ -183,16 +183,16 @@ If running Actual your your PC, you may find it useful to run this command when 
   - Create a service file:
 
     ```sudo nano /etc/systemd/system/  expose-actual-server.service```
-    - Add the following content:
+    - Add the following content and replace the relevant info:
     ```
     [Unit]
     Description=Run my Bash script at startup
     After=network.target
 
     [Service]
-    ExecStart=ngrok http --url=your-custom-domain.    ngrok-free.app 5006
+    ExecStart=ngrok http --url=<your-custom-domain>.ngrok-free.app 5006
     Restart=always
-    User=myuser
+    User=<your user>
 
     [Install]
     WantedBy=multi-user.target

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -179,7 +179,7 @@ If running Actual on your PC, you may find it helpful to run this command when y
   - Under *Action*, select the program as ngrok.exe, and add arguments ```http --url=your-custom-domain.ngrok-free.app 5006```.
   - Once complete, you can choose to run this silently in the background by navigating to *properties*, selecting *Run whether user is logged on or not*, and ticking the *Hidden* box.
 
-- On Linux you can use [systemd](https://systemd.io/)
+- On Linux, you can use [systemd](https://systemd.io/)
   - Navigate to the directory: `/etc/systemd/system/` and create a service file `expose-actual-server.service`
   - Add the following content (and change to suit your needs):
     ```

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -162,7 +162,7 @@ Apache HTTP server can serve as a reverse proxy using [VirtualHosts](https://htt
 
 ## Ngrok
 
-[Ngrok](https://ngrok.com/) offers a reverse proxy and a static domain for [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
+[Ngrok](https://ngrok.com/) offers a reverse proxy and a static domain for [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). You'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
 
 Creating a free Ngrok domain is very simple: just navigate to the Domains section of the site. For more information, check out the [custom domain docs](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/).
 

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -162,7 +162,7 @@ Apache HTTP server can serve as a reverse proxy using [VirtualHosts](https://htt
 
 ## Ngrok
 
-[Ngrok](https://ngrok.com/) offer a reverse proxy and a static domain for [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
+[Ngrok](https://ngrok.com/) offers a reverse proxy and a static domain for [free](https://ngrok.com/docs/pricing-limits/free-plan-limits/). To use it you'll need to create an account with them and follow the instructions on their [dashboard](https://dashboard.ngrok.com/) getting started section. The instructions will guide you through configuring ngrok.
 
 Creating an ngrok free domain is very simple, just navigate to the Domains section of the site. For more information, check out the [custom domain docs](https://ngrok.com/docs/guides/other-guides/how-to-set-up-a-custom-domain/).
 

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -2,11 +2,12 @@
 
 :::info
 
-Installing Actual by building it from source is a highly technical process. We recommend this approach primarily for power users and contributors.
+Installing Actual by building it from source is a highly technical process. We recommend this approach primarily for contributors.
 
-For non-technical users, we suggest opting for one of the simpler alternatives:
+For most cases, we suggest opting for one of the simpler alternatives:
 - [Pikapods](/docs/install/pikapods)
 - [Desktop Client](/download)
+- [CLI tool](/docs/install/cli-tool)
 - [Docker](/docs/install/docker)
 
 :::


### PR DESCRIPTION
I think this might be useful for people running the Actual Desktop app with the sync server. 

I might add the link to this in the desktop app dedicated docs page (when I've made it). In that page, I'll mention that a reverse proxy can expose Actual Server to the internet for free.

- https://deploy-preview-688.www.actualbudget.org/docs/config/reverse-proxies
- https://deploy-preview-688.www.actualbudget.org/docs/install/build-from-source