### PR TITLE
[WIP] Minor tweaks to the Caddy compose file

### DIFF
--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -22,6 +22,7 @@ services:
   caddy:
     image: caddy:alpine
     container_name: caddy
+    restart: unless-stopped
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./caddy/data:/data

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -34,8 +34,6 @@ services:
     image: actualbudget/actual-server:latest
     container_name: actual_server
     restart: unless-stopped
-    ports:
-      - '5006:5006'
     volumes:
       - ./actual-data:/data
 ```

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -20,8 +20,8 @@ Below is an example `Caddyfile` that you can use to configure Caddy and Actual S
 ```yaml title="docker-compose.yml"
 services:
   caddy:
-    container_name: caddy
     image: caddy:alpine
+    container_name: caddy
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./caddy/data:/data

--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -29,7 +29,7 @@ services:
       - ./caddy/config:/config
     ports:
       - "80:80"
-      - '443:443'
+      - "443:443"
 
   actual-server:
     image: actualbudget/actual-server:latest


### PR DESCRIPTION
Changes made with some justification, in order of commits:
- removed port mapping for `actual-server` service since we're using Caddy as the reverse proxy, similar to how there's no port mapping for the Traefik example
- minor consistency changes by referring to the Traefik example:
  - moved `image: caddy:alpine` to the top
  - add restart policy
  - swapped one inconsistent single-quoted port mapping to double quotes