### PR TITLE
change minimum version of Node.js to version 20

### DIFF
--- a/docs/contributing/windows.md
+++ b/docs/contributing/windows.md
@@ -4,7 +4,7 @@ Many of the build scripts are bash scripts and not natively invocable in Windows
 
 1. Install [Git & Git Bash for Windows](https://git-scm.com/downloads).
 2. Ensure you have activated [Developer Mode](https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development).
-3. Install Node v18.x or greater.
+3. Install Node v20.x or greater.
 4. Clone this repo.
 5. Using Git Bash (run as administrator), change to the root of this repo.
 6. From inside the bash shell, run `yarn install`.

--- a/docs/install/build-from-source.md
+++ b/docs/install/build-from-source.md
@@ -15,7 +15,7 @@ Actual server is used for syncing changes across devices. It comes with the late
 
 ## Prerequisites
 
-- The Actual server requires Node.js v18 or greater. You can download and install the latest version of Node.js from [Node.js website](https://nodejs.org/en/download) (we recommend downloading the “LTS” version).
+- The Actual server requires Node.js v20 or greater. You can download and install the latest version of Node.js from [Node.js website](https://nodejs.org/en/download) (we recommend downloading the “LTS” version).
   - If you're on Windows, during installation of Node.js, be sure to select _Automatically install the necessary tools_ from the _Tools for Native Modules_ page. This is required to build better-sqlite3. If you missed this when you installed Node.js, double-click ```C:\Program Files\nodejs\install_tools.bat``` from the File Explorer or run it in a terminal.
 - Consider using a tool like [nvm](https://github.com/nvm-sh/nvm) or [asdf](https://asdf-vm.com) to install and manage multiple versions of Node.js.
 - You’ll also need to have Git installed. For Windows users, you'll also need Git Bash. The Git website has [instructions for downloading and working with Git for all supported operating systems](https://git-scm.com/download).


### PR DESCRIPTION
I think I got all instances where we specify a version, there seem to only be two places in the docs.

We'll also call it out in the release notes.

https://github.com/actualbudget/actual/pull/4978