### PR TITLE
add contribution docs to repo; add PR template with PR process docs link comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,2 @@
+<!-- The process for Actual Budget Community Documentation pull requests is documented at https://actualbudget.org/docs/contributing/#submitting-a-pull-request -->
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please review the contributing documentation on our website: https://actualbudget.org/docs/contributing/


### PR DESCRIPTION
- For #695

This app's process of automatically adding "WIP" to PR titles, and waiting for the author to remove it, is clever but not one I've seen elsewhere. I for one have accidentally left a PR to this repo in limbo because of this. When I brought this up in #695, I was told that the process is documented. I tracked down the documentation in the docs site, but (unlike in the https://github.com/actualbudget/actual repo) this repo doesn't have a CONTRIBUTING file, so the process documentation is not easily discoverable while on GitHub.

This PR adds a CONTRIBUTING file identical to the app repo's. It also adds a PR template with a link to the docs.
