### PR TITLE
[WIP] Fixing a typo in the documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,4 +20,4 @@ For help and support, [reach out to the maintainers and community](/contact).
 
 ## Want to Contribute?
 
-If you'd like to contribute to the Actual Budget's documentation, click "Edit this page" to contribute. We recommend you to go through the prerequisites You can contribute to the documentation by clicking the “Edit this page” link at the bottom of any page. We also recommend you to check out documentation standard, local setup, and guidelines on using images and screenshots from [here](https://github.com/actualbudget/docs?tab=readme-ov-file).
+If you'd like to contribute to the Actual Budget's documentation, click "Edit this page" to contribute. We recommend you to go through the prerequisites. You can contribute to the documentation by clicking the “Edit this page” link at the bottom of any page. We also recommend you to check out documentation standard, local setup, and guidelines on using images and screenshots from [here](https://github.com/actualbudget/docs?tab=readme-ov-file).


### PR DESCRIPTION
Hi, this is my first time contributing to an open-source project.
I noticed a small typo in the documentation (a missing period at the end of a sentence), and I’ve submitted a fix for it.

Please feel free to suggest any improvements if I’ve done anything incorrectly. Thank you for maintaining this project!