### PR TITLE
chore: added link to correct gocardless service so people sign up to the right gocardless service

### DIFF
--- a/docs/advanced/bank-sync.md
+++ b/docs/advanced/bank-sync.md
@@ -13,7 +13,7 @@ Here are a couple of considerations to know about before making the decision to 
 
 ## Supported Providers
 
-* GoCardless (European Banks)
+* GoCardless [BankAccountData](https://gocardless.com/bank-account-data/) (European Banks)
 * SimpleFIN Bridge (North American Banks)
 * Pluggy.ai (Brazilian Banks - [**Experimental feature**](/docs/experimental/pluggyai))
 


### PR DESCRIPTION
After registering for a completely unnecessary GoCardless main account, I found out you actually need GoCardless Bank Account Data acount. Lets point other new users in the right direction.