### PR TITLE
Add <> around "path" for the OpenID redirect URI

### DIFF
--- a/docs/config/oauth-auth.md
+++ b/docs/config/oauth-auth.md
@@ -86,7 +86,7 @@ There are some basic configuration checks when clicking 'OK', but if you somehow
 :::
 
 :::tip
-When configuring your OpenID provider, be sure to register the following **redirect URI** with the provider: `https://<your-domain.tld>/path/openid/callback`
+When configuring your OpenID provider, be sure to register the following **redirect URI** with the provider: `https://<your-domain.tld>/<path>/openid/callback`
 :::
 
 #### Tested Providers


### PR DESCRIPTION
I've just spent ages trying to figure out why there was a Redirect URI mismatch. Turns out that the word "path" isn't strictly necessary for all setups, in my case, running on Fly.io. It would be helpful to distinguish that "path" is also variable depending on your setup, much like the domain.