### PR TITLE
Update reverse-proxies.md

### DIFF
--- a/docs/config/reverse-proxies.md
+++ b/docs/config/reverse-proxies.md
@@ -155,8 +155,14 @@ Apache HTTP server can serve as a reverse proxy using [VirtualHosts](https://htt
   SSLProxyEngine on
   SSLCertificateFile /etc/letsencrypt/live/example.com/fullchain.pem
   SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem
-  ProxyPass / http://127.0.0.1:5006 # this can be a remote host, or a container IP
-  ProxyPassReverse / http://127.0.0.1:5006
+
+  ProxyPreserveHost On
+  RequestHeader set X-Forwarded-Proto "https"
+  RequestHeader set X-Forwarded-Port "443"
+
+  # IP in the following lines can be a remote host, or a container IP
+  ProxyPass / http://127.0.0.1:5006/
+  ProxyPassReverse / http://127.0.0.1:5006/
 </VirtualHost>
 ```
 


### PR DESCRIPTION
Fixed an Error:
Proxy Pass & Proxy Pass Reserved need the tailing / - otherwise static assets like /static/js/ won't be accessable.

Improvement:
"ProxyPreserveHosts on" submits the host to ActualBudget (e.g. "budget.example.com")

RequestHeader set X-Forwarded-Proto "https" 
RequestHeader set X-Forwarded-Proto "443" 
Preserve an loop, if the app requires to be run with SSL