### PR TITLE
Better readability and fixes

### DIFF
--- a/docs/config/multi-user.md
+++ b/docs/config/multi-user.md
@@ -1,6 +1,10 @@
 # Managing Multi-User Support
 
-This feature requires you have setup an [OpenID Provider](oauth-auth). The usernames will be fetched from the provider.
+:::caution
+
+This feature requires you have set up an [OpenID Provider](oauth-auth). The usernames will be fetched from the provider.
+
+:::
 
 ## User Directory
 

--- a/docs/config/oauth-auth.md
+++ b/docs/config/oauth-auth.md
@@ -86,7 +86,7 @@ There are some basic configuration checks when clicking 'OK', but if you somehow
 :::
 
 :::tip
-When configuring your OpenID provider, be sure to register the following **redirect URI** with the provider: `https://<your-domain.tld>/path/openid/callback`
+When configuring your OpenID provider, be sure to register the following **redirect URI** with the provider: `https://<actual.myserver.com>/openid/callback`
 :::
 
 #### Tested Providers
@@ -115,7 +115,7 @@ When setup is done, you will be redirected to the _login_ page:
 
 #### `ACTUAL_OPENID_DISCOVERY_URL`
 - **Purpose:** If your OpenID provider supports discovery, this is the URL where discovery metadata can be found.  
-**Example Value:** `https://provider.tld/.well-known/openid-configuration`
+**Example Value:** `https://<openid-provider.com>/.well-known/openid-configuration`
 
 #### `ACTUAL_OPENID_CLIENT_ID`
 - **Purpose:** The client ID issued by your OpenID provider.  
@@ -127,19 +127,19 @@ When setup is done, you will be redirected to the _login_ page:
 
 #### `ACTUAL_OPENID_SERVER_HOSTNAME`
 - **Purpose:** The public URL of your Actual Server, which the provider redirects to after authentication.  
-**Example Value:** `https://actual.myserver.com`
+**Example Value:** `https://<actual.myserver.com>`
 
 #### `ACTUAL_OPENID_AUTHORIZATION_ENDPOINT`
 - **Purpose:** Provider’s authorization endpoint (for providers that don’t support discovery).  
-**Example Value:** `https://provider.com/oauth2/authorize`
+**Example Value:** `https://<openid-provider.com>/oauth2/authorize`
 
 #### `ACTUAL_OPENID_TOKEN_ENDPOINT`
 - **Purpose:** Provider’s token endpoint (for providers that don’t support discovery).  
-**Example Value:** `https://provider.com/oauth2/token`
+**Example Value:** `https://<openid-provider.com>/oauth2/token`
 
 #### `ACTUAL_OPENID_USERINFO_ENDPOINT`
 - **Purpose:** Provider’s user-info endpoint (for providers that don’t support discovery).  
-**Example Value:** `https://provider.com/oauth2/userinfo`
+**Example Value:** `https://<openid-provider.com>/oauth2/userinfo`
 
 #### `ACTUAL_OPENID_AUTH_METHOD`
 - **Purpose:** Tells the server whether it should use the OpenID (OIDC) or a more general OAuth2 flow.  
@@ -147,7 +147,9 @@ When setup is done, you will be redirected to the _login_ page:
   - `openid` (default)  
   - `oauth2`  
 
-**Tip:** Use `oauth2` for providers like GitHub that don’t fully support OpenID discovery.
+:::tip
+Use `oauth2` for providers like GitHub that don’t fully support OpenID discovery.
+:::
 
 #### `ACTUAL_OPENID_ENFORCE`
 - **Purpose:** Forces OpenID/OAuth2 authentication as the only allowed login method when set to `true`.  
@@ -163,3 +165,4 @@ When setup is done, you will be redirected to the _login_ page:
 
 :::tip
 Configuring the OpenID provider from options supports discovery; otherwise, use [file configuration](oauth-auth#config-using-configuration-file)
+:::


### PR DESCRIPTION
I changed two docs pages - multi user and oauth (opeid provider).

There were some minor inconsistencies and errors. I also fixed the redirect URI from `<domain>/path/openid/callback` to `<domain>/openid/callback` as the first one was incorrect for my keycloak instance.