### PR TITLE
Add Kubernetes Helm Charts section to Community Projects page

### DIFF
--- a/docs/community-repos.md
+++ b/docs/community-repos.md
@@ -72,6 +72,14 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
    - *An iOS widget to display your Actual Budget category balances for the current month. Requires your Actual server to be accessible via HTTPS, and the **Local REST API** community project to be installed.*
 
 
+## Kubernetes Helm Charts
+
+* **Community Charts** - https://github.com/community-charts/helm-charts/tree/main/charts/actualbudget
+   - A Helm chart for deploying Actual Budget on Kubernetes, enabling easy setup and management of containerized Actual Budget instances with customizable configurations.
+   - **ArtifactHub** - https://artifacthub.io/packages/helm/community-charts/actualbudget
+   - **Documentation** - https://community-charts.github.io/docs/charts/actualbudget/usage
+
+
 ## Others
 
 * **Amazon orders CSV exporter user script** - https://github.com/IeuanK/AmazonExporter/


### PR DESCRIPTION
Hi Actual Budget contributors,

As previously mentioned in the [#documentation channel on Discord](https://discord.com/channels/937901803608096828/1027831463103696928/1401185613331300382), I've proposed adding the community-driven Kubernetes Helm Charts to the Community Projects page. Following @MatissJanis 's suggestion, I'm opening this pull request to contribute that addition.

If you have any questions or feedback, feel free to reach out - I'm happy to help!

Best regards,
Burak Ince