### PR TITLE
[WIP] Adding bank: fixed instructions order

### DIFF
--- a/docs/advanced/bank-sync/gocardless.md
+++ b/docs/advanced/bank-sync/gocardless.md
@@ -125,10 +125,9 @@ To achieve this:
 3. Fork the Actual repository: https://github.com/actualbudget/actual/fork
 4. Edit the file `packages/sync-server/src/app-gocardless/bank-factory.js`.
 5. Add your bank's ID (from the Google Docs) to the `BANKS_WITH_LIMITED_HISTORY` list.
-6. Commit your changes and push to your fork.
-7. Add a release note in `upcoming-release-notes/` describing your change (see [writing good release notes](/docs/contributing/#writing-good-release-notes)).
-8. Commit your changes and push to your fork.
-9. Create a pull request to the main Actual repository.
+6. Add a release note in `upcoming-release-notes/` describing your change (see [writing good release notes](/docs/contributing/#writing-good-release-notes)).
+7. Commit your changes and push to your fork.
+8. Create a pull request to the main Actual repository.
 
 
 Once reviewed, the maintainers will comment on the pull request and merge it if acceptable. The change would then be available in the next release of the software.

--- a/docs/advanced/bank-sync/gocardless.md
+++ b/docs/advanced/bank-sync/gocardless.md
@@ -125,7 +125,7 @@ To achieve this:
 3. Fork the Actual repository: https://github.com/actualbudget/actual/fork
 4. Edit the file `packages/sync-server/src/app-gocardless/bank-factory.js`.
 5. Add your bank's ID (from the Google Docs) to the `BANKS_WITH_LIMITED_HISTORY` list.
-6. Add a release note in `upcoming-release-notes/` describing your change (see [writing good release notes](/docs/contributing/#writing-good-release-notes)).
+6. Before creating your pull request, run the command `yarn generate:release-notes` (see [writing good release notes](/docs/contributing/#writing-good-release-notes)).
 7. Commit your changes and push to your fork.
 8. Create a pull request to the main Actual repository.
 

--- a/docs/advanced/bank-sync/gocardless.md
+++ b/docs/advanced/bank-sync/gocardless.md
@@ -126,9 +126,10 @@ To achieve this:
 4. Edit the file `packages/sync-server/src/app-gocardless/bank-factory.js`.
 5. Add your bank's ID (from the Google Docs) to the `BANKS_WITH_LIMITED_HISTORY` list.
 6. Commit your changes and push to your fork.
-7. Create a pull request to the main Actual repository.
-8. Add a release note in `upcoming-release-notes/` describing your change (see [writing good release notes](/docs/contributing/#writing-good-release-notes)).
-9. Commit your changes and push to your fork.
+7. Add a release note in `upcoming-release-notes/` describing your change (see [writing good release notes](/docs/contributing/#writing-good-release-notes)).
+8. Commit your changes and push to your fork.
+9. Create a pull request to the main Actual repository.
+
 
 Once reviewed, the maintainers will comment on the pull request and merge it if acceptable. The change would then be available in the next release of the software.
 


### PR DESCRIPTION
I encountered this issue when I [created a PR](https://github.com/actualbudget/actual/pull/5479) to add a new bank to Actual. 
The docs were instructing me to first create the PR and then generate the docs. 

At the same time, when I tried to open the PR, the default template message was instructing me to generate the release notes *before* opening the PR. 

```
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
```

I am not sure who is telling the truth here, but given the emphasis that the template put on *before* I am inferring that the docs had the wrong order. If this is not the case, of course feel free to nuke this PR and update the GitHub template instead. 