### PR TITLE
Make Experimental Features installation instructions more obvious

### DIFF
--- a/docs/experimental/goal-templates.md
+++ b/docs/experimental/goal-templates.md
@@ -4,7 +4,7 @@
 This is an **experimental feature**. That means we’re still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord.
 :::
 :::warning
-All functionality described here may not be available in the latest stable release. Use the `edge` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](./index) for instructions to enable experimental features. Use the `edge` images for the latest implementation.
 :::
 
 Budget templates allow you to automate your budgeting step every month.

--- a/docs/experimental/monthly-cleanup.md
+++ b/docs/experimental/monthly-cleanup.md
@@ -1,7 +1,7 @@
 # End of Month Cleanup
 
 :::warning
-This is an **experimental feature**. That means we’re still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord.
+This is an **experimental feature**. That means we’re still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord. See [Experimental Features](./index) for instructions to enable experimental features.
 :::
 
 Create a template by adding a note to a category and adding a line that begins with `#cleanup`.

--- a/docs/experimental/rule-templating.md
+++ b/docs/experimental/rule-templating.md
@@ -4,7 +4,7 @@
 This is an **experimental feature**. That means we’re still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord.
 :::
 :::warning
-All functionality described here may not be available in the latest stable release. Use the `edge` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](./index) for instructions to enable experimental features. Use the `edge` images for the latest implementation.
 :::
 
 Rule action templating allows rules to dynamically set fields based on transaction data via meta programming inside the rule.


### PR DESCRIPTION
I could not find instructions on the [Budget Templates](https://actualbudget.org/docs/experimental/goal-templates) experimental feature docs page for how to enable the feature.  I did not look closely enough at the advanced settings to realize I had to click a link, even though I had looked at the setting page.  

After asking in discord, I was told how to enable the feature, and even found that there was a parent page [Experimental Features](https://actualbudget.org/docs/experimental/) which had the instructions I would have needed.   

This PR simply adds a short sentence with a link back to that root page on the experimental features pages. This would have helped me find my own solution without needing to ask.

I did not add anything to the [Pluggy.ai Setup](https://actualbudget.org/docs/experimental/pluggyai) page because it has the blurb `Pluggy integration is experimental at this point, so before you can use it you need to enable it under Settings -> Advanced Settings -> Experimental Features -> Pluggy.ai Bank Sync` in the page and didn't have the same callout sections at the warning callout sections as the other pages at the top.