### PR TITLE
Added more notice that GoCardless no longer accepts new accounts.

### DIFF
--- a/docs/advanced/bank-sync.md
+++ b/docs/advanced/bank-sync.md
@@ -13,7 +13,7 @@ Here are a couple of considerations to know about before making the decision to 
 
 ## Supported Providers
 
-* GoCardless [BankAccountData](/docs/advanced/bank-sync/gocardless/) (European Banks)
+* GoCardless [BankAccountData](/docs/advanced/bank-sync/gocardless/) (European Banks, **not accepting new signups**)
 * SimpleFIN Bridge (North American Banks)
 * Pluggy.ai (Brazilian Banks - [**Experimental feature**](/docs/experimental/pluggyai))
 

--- a/docs/getting-started/starting-fresh.md
+++ b/docs/getting-started/starting-fresh.md
@@ -49,7 +49,7 @@ If your starting date is before the current date, edit the date on the starting 
 
 Once your account has the proper starting balance, add all the transactions between your start date and today.
 You can enter transactions [manually](../transactions/importing.md#manually-add-transactions), via [file import](../transactions/importing.md#import-financial-files), or via bank syncing to pull in transactions.
-For bank syncing, Actual has built-in support for [GoCardless](../advanced/bank-sync.md) which works for most EU/UK banks, and SimpleFIN for US/Canadian banks.
+For bank syncing, Actual has built-in support for [GoCardless](../advanced/bank-sync.md) which works for most EU/UK banks, and SimpleFIN for US/Canadian banks. Note: GoCardless has stopped accepting signups for this service.
 For other bank syncing options see the [community projects page](../community-repos.md).
 
 An optional step after you have created your accounts and added your transactions is to reconcile the account.


### PR DESCRIPTION
Users will attempt to install actual, and connect it, but then find they cannot sign up, so pointing this out earlier is a good thing.

Ideally in the docs page actual should stop advertising it at all, and simply leave the instructions there for people who already have accounts, but not mention it in the features and such.