### PR TITLE
Fix minor spelling error

### DIFF
--- a/docs/advanced/restart.md
+++ b/docs/advanced/restart.md
@@ -2,7 +2,7 @@
 
 If you've fallen behind on your budgeting and want to start fresh without starting from scratch.
 
-This means that you want to reset your budget while keeping your categories, payees, rules and schedules. Bellow we have described two methods to restart your budget: one by deleting all transactions and another without deleting any transactions.
+This means that you want to reset your budget while keeping your categories, payees, rules and schedules. Below we have described two methods to restart your budget: one by deleting all transactions and another without deleting any transactions.
 
 If you're ok with truly starting completely from scratch, [just make a new file](/docs/getting-started/starting-fresh/).
 


### PR DESCRIPTION
Fix a minor spelling error in `docs/advanced/restart.md`.